### PR TITLE
features/windows test 7z

### DIFF
--- a/.github/workflows/sidecar-windows.yaml
+++ b/.github/workflows/sidecar-windows.yaml
@@ -23,7 +23,7 @@ jobs:
     
     - name: Run 7z action
       run: |
-        7z a -t7z "sidecar_test.7z" "onnxruntime/" "qdrant/" "models/"
+        7z a -t7z "sidecar_test.7z" "onnxruntime/" "qdrant/" "models/" "src\\agent\\llm_funcs.rs"
 
     # Install gcp skcd
     - name: Setup GCP SDK
@@ -65,7 +65,7 @@ jobs:
     # Github action parser for sure, something to test it out too quickly
     - name: Compile the 7z
       run: |
-        7z a -t7z "sidecar.7z" "onnxruntime/" "qdrant/" "target/release/webserver" "models/"
+        7z a -t7z "sidecar.7z" "onnxruntime/" "qdrant/" "target\\release\\webserver" "models/"
 
     - name: Upload to GCP bucket generated zip file
       env:


### PR DESCRIPTION
- [sidecar] try and zip windows bin using 7z
- [sidecar] rename the file which is generated
- [sidecar] add test upload to gcp on windows
- [sidecar] uses the 7z action instead
- [sidecar] use the action properly
- [sidecar] use the bash shell instead
- [sidecar] compress it on bash
- [sidecar] push the fix
- [sidecar] try to use normal runs
- [sidecar] how to use this properly 7z
- [sidecar] change the path how it looks like in windows
