### PR TITLE
add compile-time flag for teeing requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,6 +3083,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.56",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,6 +3013,7 @@ dependencies = [
  "futures",
  "logging",
  "reqwest 0.11.23",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "sqlx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http 1.2.0",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -2471,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -2498,7 +2498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -2509,7 +2509,7 @@ checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "pin-project-lite",
 ]
@@ -2578,7 +2578,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "httparse",
  "itoa",
@@ -2595,7 +2595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "hyper 1.5.2",
  "hyper-util",
  "rustls 0.23.21",
@@ -2643,7 +2643,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "hyper 1.5.2",
  "pin-project-lite",
@@ -3109,6 +3109,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "http 1.2.0",
  "reqwest",
  "reqwest-middleware",
  "serde",
@@ -4253,7 +4254,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.5.2",
@@ -4317,7 +4318,7 @@ checksum = "d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.1.0",
+ "http 1.2.0",
  "reqwest",
  "serde",
  "thiserror 1.0.56",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4793,6 +4793,7 @@ dependencies = [
  "regex",
  "relative-path",
  "reqwest 0.11.23",
+ "reqwest-middleware",
  "scc",
  "select",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
  "eventsource-stream",
  "futures",
  "rand",
- "reqwest 0.12.12",
+ "reqwest",
  "reqwest-eventsource",
  "secrecy",
  "serde",
@@ -2620,19 +2620,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.27",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -3054,7 +3041,7 @@ dependencies = [
  "eventsource-stream",
  "futures",
  "logging",
- "reqwest 0.12.12",
+ "reqwest",
  "reqwest-middleware",
  "serde",
  "serde_json",
@@ -3122,7 +3109,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "reqwest 0.11.23",
+ "reqwest",
  "reqwest-middleware",
  "serde",
  "serde_json",
@@ -4255,44 +4242,6 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
-dependencies = [
- "base64 0.21.5",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.21",
- "http 0.2.11",
- "http-body 0.4.5",
- "hyper 0.14.27",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
@@ -4309,7 +4258,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.5.2",
  "hyper-rustls",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -4329,7 +4278,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -4356,7 +4305,7 @@ dependencies = [
  "mime",
  "nom",
  "pin-project-lite",
- "reqwest 0.12.12",
+ "reqwest",
  "thiserror 1.0.56",
 ]
 
@@ -4369,7 +4318,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.1.0",
- "reqwest 0.12.12",
+ "reqwest",
  "serde",
  "thiserror 1.0.56",
  "tower-service",
@@ -4839,7 +4788,7 @@ dependencies = [
  "rayon",
  "regex",
  "relative-path",
- "reqwest 0.12.12",
+ "reqwest",
  "reqwest-middleware",
  "scc",
  "select",
@@ -5338,34 +5287,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.3",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.8.0",
  "core-foundation 0.9.3",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -6553,16 +6481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,7 +3054,7 @@ dependencies = [
  "eventsource-stream",
  "futures",
  "logging",
- "reqwest 0.11.23",
+ "reqwest 0.12.12",
  "reqwest-middleware",
  "serde",
  "serde_json",
@@ -4283,12 +4283,10 @@ dependencies = [
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.3.0",
  "web-sys",
  "winreg",
 ]
@@ -4302,6 +4300,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.7",
@@ -4340,7 +4339,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.0",
+ "wasm-streams",
  "web-sys",
  "windows-registry",
 ]
@@ -6184,19 +6183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,6 +2322,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.1.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,7 +2554,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.21",
  "http 0.2.11",
  "http-body 0.4.5",
  "httparse",
@@ -2552,6 +2577,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.7",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -2603,6 +2629,22 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -4222,11 +4264,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.21",
  "http 0.2.11",
  "http-body 0.4.5",
  "hyper 0.14.27",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -4238,7 +4280,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -4259,19 +4301,23 @@ checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2 0.4.7",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.5.2",
  "hyper-rustls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4284,7 +4330,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
+ "system-configuration 0.6.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
@@ -4792,7 +4840,7 @@ dependencies = [
  "rayon",
  "regex",
  "relative-path",
- "reqwest 0.11.23",
+ "reqwest 0.12.12",
  "reqwest-middleware",
  "scc",
  "select",
@@ -5297,7 +5345,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.3",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.9.3",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -5305,6 +5364,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5606,7 +5675,7 @@ dependencies = [
  "axum",
  "base64 0.21.5",
  "bytes",
- "h2",
+ "h2 0.3.21",
  "http 0.2.11",
  "http-body 0.4.5",
  "hyper 0.14.27",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,6 +3080,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "reqwest 0.11.23",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "thiserror 1.0.56",
@@ -4309,6 +4310,21 @@ dependencies = [
  "pin-project-lite",
  "reqwest 0.12.12",
  "thiserror 1.0.56",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.1.0",
+ "reqwest 0.12.12",
+ "serde",
+ "thiserror 1.0.56",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,38 +148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "async-convert"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
-dependencies = [
- "async-trait",
-]
-
-[[package]]
-name = "async-openai"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e1df052c2bd7b241fc828bc2fda74ce9a7ef05e0a593c37275aaaba52caf49d"
-dependencies = [
- "async-convert",
- "backoff",
- "base64 0.21.5",
- "derive_builder 0.12.0",
- "futures",
- "rand",
- "reqwest 0.11.23",
- "reqwest-eventsource 0.4.0",
- "serde",
- "serde_json",
- "thiserror 1.0.56",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "async-openai"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,7 +161,7 @@ dependencies = [
  "futures",
  "rand",
  "reqwest 0.12.12",
- "reqwest-eventsource 0.6.0",
+ "reqwest-eventsource",
  "secrecy",
  "serde",
  "serde_json",
@@ -2596,20 +2564,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.11",
- "hyper 0.14.27",
- "rustls 0.21.8",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
@@ -2619,10 +2573,10 @@ dependencies = [
  "hyper 1.5.2",
  "hyper-util",
  "rustls 0.23.21",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -3051,7 +3005,7 @@ name = "llm_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-openai 0.27.1",
+ "async-openai",
  "async-trait",
  "chrono",
  "either",
@@ -4269,27 +4223,21 @@ dependencies = [
  "http 0.2.11",
  "http-body 0.4.5",
  "hyper 0.14.27",
- "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.8",
- "rustls-native-certs 0.6.3",
- "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -4314,7 +4262,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.5.2",
- "hyper-rustls 0.27.5",
+ "hyper-rustls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -4326,7 +4274,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.21",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -4334,7 +4282,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
  "tower-service",
@@ -4344,22 +4292,6 @@ dependencies = [
  "wasm-streams 0.4.0",
  "web-sys",
  "windows-registry",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f03f570355882dd8d15acc3a313841e6e90eddbc76a93c748fd82cc13ba9f51"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest 0.11.23",
- "thiserror 1.0.56",
 ]
 
 [[package]]
@@ -4467,7 +4399,6 @@ version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
- "log",
  "ring",
  "rustls-webpki 0.101.7",
  "sct",
@@ -4485,18 +4416,6 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.9.2",
 ]
 
 [[package]]
@@ -4799,7 +4718,7 @@ name = "sidecar"
 version = "0.1.20"
 dependencies = [
  "anyhow",
- "async-openai 0.14.3",
+ "async-openai",
  "async-recursion",
  "async-stream",
  "async-trait",
@@ -5620,16 +5539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.8",
  "tokio",
 ]
 

--- a/llm_client/Cargo.toml
+++ b/llm_client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.77"
 anyhow = "1.0.75"
-reqwest = { version = "0.11.23", features = ["blocking", "json", "stream"] }
+reqwest = { version = "0.12.12", features = ["blocking", "json", "stream"] }
 serde = "1.0.195"
 serde_json = "1.0.111"
 eventsource-stream = "0.2.3"

--- a/llm_client/Cargo.toml
+++ b/llm_client/Cargo.toml
@@ -3,6 +3,9 @@ name = "llm_client"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+tee_requests = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/llm_client/Cargo.toml
+++ b/llm_client/Cargo.toml
@@ -28,3 +28,4 @@ uuid = { version = "1.4.1", features = ["v4"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 
 logging = { path = "../logging" }
+reqwest-middleware = { version = "0.4.0", features = ["json"] }

--- a/llm_client/src/clients/anthropic.rs
+++ b/llm_client/src/clients/anthropic.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
+use logging::new_client;
 use logging::parea::{PareaClient, PareaLogCompletion, PareaLogMessage};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::debug;
@@ -354,7 +355,7 @@ impl AnthropicRequest {
 }
 
 pub struct AnthropicClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
     base_url: String,
     chat_endpoint: String,
 }
@@ -362,7 +363,7 @@ pub struct AnthropicClient {
 impl AnthropicClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
             base_url: "https://api.anthropic.com".to_owned(),
             chat_endpoint: "/v1/messages".to_owned(),
         }
@@ -370,7 +371,7 @@ impl AnthropicClient {
 
     pub fn new_with_custom_urls(base_url: String, chat_endpoint: String) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
             base_url,
             chat_endpoint,
         }

--- a/llm_client/src/clients/codestory.rs
+++ b/llm_client/src/clients/codestory.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-
+use logging::new_client;
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
@@ -31,7 +31,7 @@ struct Choice {
 }
 
 pub struct CodeStoryClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
     api_base: String,
 }
 
@@ -99,11 +99,11 @@ impl CodeStoryClient {
     pub fn new(api_base: &str) -> Self {
         Self {
             api_base: api_base.to_owned(),
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 

--- a/llm_client/src/clients/fireworks.rs
+++ b/llm_client/src/clients/fireworks.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
+use logging::new_client;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::provider::LLMProviderAPIKeys;
@@ -116,13 +117,13 @@ impl FireworksAIRequestString {
 }
 
 pub struct FireworksAIClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
     base_url: String,
 }
 
 impl FireworksAIClient {
     pub fn new() -> Self {
-        let client = reqwest::Client::new();
+        let client = new_client();
         Self {
             client,
             base_url: "https://api.fireworks.ai/inference/v1".to_owned(),

--- a/llm_client/src/clients/gemini_pro.rs
+++ b/llm_client/src/clients/gemini_pro.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::provider::{LLMProvider, LLMProviderAPIKeys};
+use logging::new_client;
 
 use super::types::{
     LLMClient, LLMClientCompletionRequest, LLMClientCompletionResponse,
@@ -14,13 +15,13 @@ use super::types::{
 };
 
 pub struct GeminiProClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl GeminiProClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 

--- a/llm_client/src/clients/google_ai.rs
+++ b/llm_client/src/clients/google_ai.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
+use logging::new_client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -14,13 +15,13 @@ use super::types::{
 };
 
 pub struct GoogleAIStdioClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl GoogleAIStdioClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 

--- a/llm_client/src/clients/lmstudio.rs
+++ b/llm_client/src/clients/lmstudio.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
+use logging::new_client;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::provider::{LLMProvider, LLMProviderAPIKeys};
@@ -22,7 +23,7 @@ struct Choice {
 }
 
 pub struct LMStudioClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
@@ -94,7 +95,7 @@ impl LMStudioRequest {
 impl LMStudioClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 

--- a/llm_client/src/clients/ollama.rs
+++ b/llm_client/src/clients/ollama.rs
@@ -1,6 +1,7 @@
 //! Ollama client here so we can send requests to it
 
 use async_trait::async_trait;
+use logging::new_client;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::provider::LLMProviderAPIKeys;
@@ -13,7 +14,7 @@ use super::types::LLMClientError;
 use super::types::LLMType;
 
 pub struct OllamaClient {
-    pub client: reqwest::Client,
+    pub client: reqwest_middleware::ClientWithMiddleware,
     pub base_url: String,
 }
 
@@ -99,7 +100,7 @@ impl OllamaClient {
         // ollama always runs on the following url:
         // http://localhost:11434/
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
             base_url: "http://localhost:11434".to_owned(),
         }
     }

--- a/llm_client/src/clients/open_router.rs
+++ b/llm_client/src/clients/open_router.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::provider::{LLMProvider, LLMProviderAPIKeys};
 use futures::StreamExt;
+use logging::new_client;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::types::{
@@ -153,7 +154,7 @@ impl OpenRouterRequestMessageToolUse {
 * State is persistent across command calls and discussions with the user
 * If `path` is a file, `view` displays the result of applying `cat -n`. If `path` is a directory, `view` lists non-hidden files and directories up to 2 levels deep
 * The `create` command cannot be used if the specified `path` already exists as a file
-* If a `command` generates a long output, it will be truncated and marked with `<response clipped>` 
+* If a `command` generates a long output, it will be truncated and marked with `<response clipped>`
 * The `undo_edit` command will revert the last edit made to the file at `path`
 
 Notes for using the `str_replace` command:
@@ -353,13 +354,13 @@ impl OpenRouterRequest {
 }
 
 pub struct OpenRouterClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl OpenRouterClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 

--- a/llm_client/src/clients/togetherai.rs
+++ b/llm_client/src/clients/togetherai.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
+use logging::new_client;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::provider::LLMProviderAPIKeys;
@@ -13,7 +14,7 @@ use super::types::LLMClientError;
 use super::types::LLMType;
 
 pub struct TogetherAIClient {
-    pub client: reqwest::Client,
+    pub client: reqwest_middleware::ClientWithMiddleware,
     pub base_url: String,
 }
 
@@ -124,9 +125,8 @@ impl TogetherAIRequestString {
 
 impl TogetherAIClient {
     pub fn new() -> Self {
-        let client = reqwest::Client::new();
         Self {
-            client,
+            client: new_client(),
             base_url: "https://api.together.xyz/v1".to_owned(),
         }
     }

--- a/llm_client/src/clients/types.rs
+++ b/llm_client/src/clients/types.rs
@@ -935,6 +935,9 @@ pub enum LLMClientError {
     #[error("Reqwest error: {0}")]
     ReqwestError(#[from] reqwest::Error),
 
+    #[error("ReqwestMiddlewareError error: {0}")]
+    ReqwestMiddlewareError(#[from] reqwest_middleware::Error),
+
     #[error("serde failed: {0}")]
     SerdeError(#[from] serde_json::Error),
 

--- a/llm_client/src/format/types.rs
+++ b/llm_client/src/format/types.rs
@@ -84,7 +84,7 @@ pub enum TokenizerError {
     FailedToGetResponse,
 
     #[error("Reqwest error: {0}")]
-    ReqwestError(#[from] reqwest::Error),
+    ReqwestError(#[from] reqwest_middleware::Error),
 
     #[error("serde failed: {0}")]
     SerdeError(#[from] serde_json::Error),

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -3,6 +3,9 @@ name = "logging"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+tee_requests = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.77"
 anyhow = "1.0.75"
-reqwest = "0.11.23"
+reqwest = "0.12.12"
 thiserror = "1.0.49"
 serde_json = "1.0.117"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -15,3 +15,4 @@ serde = { version = "1.0.188", features = ["derive"] }
 chrono = "0.4.38"
 tokio = "1.32.0"
 reqwest-middleware = { version = "0.4.0", features = ["json"] }
+http = "1.2.0"

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -13,3 +13,4 @@ thiserror = "1.0.49"
 serde_json = "1.0.117"
 serde = { version = "1.0.188", features = ["derive"] }
 chrono = "0.4.38"
+tokio = "1.32.0"

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = "1.0.117"
 serde = { version = "1.0.188", features = ["derive"] }
 chrono = "0.4.38"
 tokio = "1.32.0"
+reqwest-middleware = { version = "0.4.0", features = ["json"] }

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -1,3 +1,7 @@
 //! Contains the logging crate
 
 pub mod parea;
+#[cfg(feature = "tee_requests")]
+pub mod tee_middleware;
+mod tee_client;
+pub use tee_client::new_client;

--- a/logging/src/mod.rs
+++ b/logging/src/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "tee_requests")]
+mod tee_middleware;

--- a/logging/src/tee_client.rs
+++ b/logging/src/tee_client.rs
@@ -1,0 +1,15 @@
+use reqwest_middleware::{ClientWithMiddleware, ClientBuilder};
+
+pub fn new_client() -> ClientWithMiddleware {
+    #[cfg(feature = "tee_requests")]
+    {
+        ClientBuilder::new(reqwest::Client::new())
+            .with(crate::tee_middleware::TeeMiddleware::new())
+            .build()
+    }
+
+    #[cfg(not(feature = "tee_requests"))]
+    {
+        ClientBuilder::new(reqwest::Client::new()).build()
+    }
+}

--- a/logging/src/tee_middleware.rs
+++ b/logging/src/tee_middleware.rs
@@ -1,0 +1,74 @@
+use reqwest::{Client, Request, Response};
+use reqwest_middleware::{Middleware, Next, Result};
+use http::Extensions;
+use std::env;
+use tokio;
+
+pub fn tee_server_url() -> String {
+    env::var("AIDE_TEE_URL")
+        .unwrap_or_else(|_| "http://localhost:8080".to_string())
+}
+
+pub struct TeeMiddleware {
+    tee_client: Client,
+}
+
+impl TeeMiddleware {
+    pub fn new() -> Self {
+        Self {
+            tee_client: Client::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Middleware for TeeMiddleware {
+    async fn handle(
+        &self,
+        req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> Result<Response> {
+        let path = req.url().path();
+        let full_url = format!("{}/sidecar_request{}", tee_server_url(), path);
+
+        let body = req.try_clone().and_then(|req| {
+            req.body().map(|body| {
+                body.as_bytes().map_or_else(
+                    || Vec::new(),
+                    |bytes| bytes.to_vec()
+                )
+            })
+        });
+
+        let endpoint = req.url().host_str()
+            .map(|host| {
+                if let Some(port) = req.url().port() {
+                    format!("{}:{}", host, port)
+                } else {
+                    host.to_string()
+                }
+            })
+            .unwrap_or_else(|| "none".to_string());
+        let mut headers = req.headers().clone();
+        headers.append("endpoint", endpoint.parse().unwrap());
+
+        let tee_request = self.tee_client
+            .request(req.method().clone(), full_url)
+            .headers(headers);
+
+        let tee_request = if let Some(body) = body {
+            tee_request.body(body)
+        } else {
+            tee_request
+        };
+
+        // Spawn the tee request into a separate non-blocking task, we don't care about
+        // its result
+        tokio::spawn(async move {
+            let _ = tee_request.send().await;
+        });
+
+        next.run(req, extensions).await
+    }
+}

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -60,7 +60,7 @@ pest_derive = "2.7.4"
 fuzzy-matcher = "0.3.7"
 uuid = {version = "1.4.1", features = ["serde"] }
 compact_str = "0.7.1"
-async-openai = "0.14.3"
+async-openai = "0.27.1"
 reqwest = "0.11.22"
 chrono = { version = "0.4.31", features = ["serde"] }
 tiktoken-rs = "0.5.4"

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -61,7 +61,7 @@ fuzzy-matcher = "0.3.7"
 uuid = {version = "1.4.1", features = ["serde"] }
 compact_str = "0.7.1"
 async-openai = "0.27.1"
-reqwest = "0.11.22"
+reqwest = "0.12.12"
 chrono = { version = "0.4.31", features = ["serde"] }
 tiktoken-rs = "0.5.4"
 rake = "0.3.3"

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 
 [features]
 ee = []
+tee_requests = []
 
 [dependencies]
 libcaesium = { version = "0.17.1", default-features = false, features = ["jpg", "png"] }

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -99,6 +99,7 @@ globset = "0.4.15"
 dirs = "5.0.1"
 diffy = "0.4.0"
 colored = "2.1.0"
+reqwest-middleware = "0.4.0"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26.2", default-features = false, features = [ "resource" ] }

--- a/sidecar/src/agentic/tool/code_edit/search_and_replace.rs
+++ b/sidecar/src/agentic/tool/code_edit/search_and_replace.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use futures::{lock::Mutex, StreamExt};
+use logging::new_client;
 use std::path::Path;
 use std::{collections::HashMap, sync::Arc};
 use tokio::io::AsyncWriteExt;
@@ -167,15 +168,16 @@ impl SearchAndReplaceEditingRequest {
 }
 
 pub struct StreamedEditingForEditor {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl StreamedEditingForEditor {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
+
 
     pub async fn send_edit_event(
         &self,

--- a/sidecar/src/agentic/tool/editor/apply.rs
+++ b/sidecar/src/agentic/tool/editor/apply.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use logging::new_client;
 
 use crate::{
     agentic::tool::{
@@ -11,14 +12,14 @@ use crate::{
 };
 
 pub struct EditorApply {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
     apply_edits_directly: bool,
 }
 
 impl EditorApply {
     pub fn new(apply_edits_directly: bool) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
             apply_edits_directly,
         }
     }

--- a/sidecar/src/agentic/tool/git/edited_files.rs
+++ b/sidecar/src/agentic/tool/git/edited_files.rs
@@ -9,6 +9,7 @@ use crate::agentic::tool::{
     r#type::{Tool, ToolRewardScale},
 };
 use async_trait::async_trait;
+use logging::new_client;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct EditedFilesRequest {
@@ -63,13 +64,13 @@ impl EditedFilesResponse {
 }
 
 pub struct EditedFiles {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl EditedFiles {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/create_file.rs
+++ b/sidecar/src/agentic/tool/lsp/create_file.rs
@@ -7,6 +7,7 @@ use crate::agentic::tool::{
     r#type::{Tool, ToolRewardScale},
 };
 use async_trait::async_trait;
+use logging::new_client;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,13 +46,13 @@ impl CreateFileResponse {
 }
 
 pub struct LSPCreateFile {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl LSPCreateFile {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/get_outline_nodes.rs
+++ b/sidecar/src/agentic/tool/lsp/get_outline_nodes.rs
@@ -5,6 +5,7 @@
 //! that we should see how well it works for the languages we are interested in
 
 use async_trait::async_trait;
+use logging::new_client;
 
 use crate::{
     agentic::tool::{
@@ -409,13 +410,13 @@ impl OutlineNodesUsingEditorRequest {
 }
 
 pub struct OutlineNodesUsingEditorClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl OutlineNodesUsingEditorClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/go_to_previous_word.rs
+++ b/sidecar/src/agentic/tool/lsp/go_to_previous_word.rs
@@ -10,6 +10,7 @@ use crate::{
     chunking::text_document::{Position, Range},
 };
 use async_trait::async_trait;
+use logging::new_client;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GoToPreviousWordRequest {
@@ -41,13 +42,13 @@ impl GoToPreviousWordResponse {
 }
 
 pub struct GoToPreviousWordClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl GoToPreviousWordClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/gotodefintion.rs
+++ b/sidecar/src/agentic/tool/lsp/gotodefintion.rs
@@ -8,6 +8,7 @@ use crate::{
     chunking::text_document::{Position, Range},
 };
 use async_trait::async_trait;
+use logging::new_client;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GoToDefinitionRequest {
@@ -62,13 +63,13 @@ impl DefinitionPathAndRange {
 }
 
 pub struct LSPGoToDefinition {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl LSPGoToDefinition {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/gotoimplementations.rs
+++ b/sidecar/src/agentic/tool/lsp/gotoimplementations.rs
@@ -8,6 +8,7 @@ use crate::{
     chunking::text_document::{Position, Range},
 };
 use async_trait::async_trait;
+use logging::new_client;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GoToImplementationRequest {
@@ -58,13 +59,13 @@ impl GoToImplementationResponse {
 }
 
 pub struct LSPGoToImplementation {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl LSPGoToImplementation {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/gotoreferences.rs
+++ b/sidecar/src/agentic/tool/lsp/gotoreferences.rs
@@ -17,6 +17,7 @@ use crate::{
         types::OutlineNode,
     },
 };
+use logging::new_client;
 
 #[derive(Debug, Clone)]
 pub struct AnchoredReference {
@@ -149,13 +150,13 @@ impl GoToReferencesRequest {
 }
 
 pub struct LSPGoToReferences {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl LSPGoToReferences {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/gototypedefinition.rs
+++ b/sidecar/src/agentic/tool/lsp/gototypedefinition.rs
@@ -6,19 +6,20 @@ use crate::agentic::tool::{
     r#type::{Tool, ToolRewardScale},
 };
 use async_trait::async_trait;
+use logging::new_client;
 
 use super::gotodefintion::GoToDefinitionResponse;
 
 /// We are resuing the types from go to definition since the response and the request
 /// are the one and the same
 pub struct LSPGoToTypeDefinition {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl LSPGoToTypeDefinition {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/grep_symbol.rs
+++ b/sidecar/src/agentic/tool/lsp/grep_symbol.rs
@@ -8,6 +8,7 @@ use crate::{
     chunking::text_document::Range,
 };
 use async_trait::async_trait;
+use logging::new_client;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LSPGrepSymbolInCodebaseRequest {
@@ -53,13 +54,13 @@ impl LSPGrepSymbolInCodebaseRequest {
 }
 
 pub struct GrepSymbolInCodebase {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl GrepSymbolInCodebase {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/inlay_hints.rs
+++ b/sidecar/src/agentic/tool/lsp/inlay_hints.rs
@@ -10,6 +10,7 @@ use crate::{
     chunking::text_document::{Position, Range},
 };
 use async_trait::async_trait;
+use logging::new_client;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct InlayHintsRequest {
@@ -70,13 +71,13 @@ impl InlayHintsResponse {
 }
 
 pub struct InlayHints {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl InlayHints {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/open_file.rs
+++ b/sidecar/src/agentic/tool/lsp/open_file.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use gix::bstr::ByteSlice;
+use logging::new_client;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OpenFileRequestPartial {
@@ -280,13 +281,13 @@ impl OpenFileResponse {
 }
 
 pub struct LSPOpenFile {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl LSPOpenFile {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/quick_fix.rs
+++ b/sidecar/src/agentic/tool/lsp/quick_fix.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     chunking::text_document::Range,
 };
+use logging::new_client;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GetQuickFixRequest {
@@ -57,13 +58,13 @@ impl GetQuickFixResponse {
 }
 
 pub struct LSPQuickFixClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl LSPQuickFixClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }
@@ -140,13 +141,13 @@ impl LSPQuickFixInvocationResponse {
 }
 
 pub struct LSPQuickFixInvocationClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl LSPQuickFixInvocationClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/search_file.rs
+++ b/sidecar/src/agentic/tool/lsp/search_file.rs
@@ -2,6 +2,7 @@
 //! Can be used by the agent to grep for this in the repository or in a sub-directory
 
 use async_trait::async_trait;
+use logging::new_client;
 use tokio::io::AsyncBufReadExt;
 use tokio::{io::BufReader, process::Command};
 
@@ -239,13 +240,13 @@ struct EditorRipGrepPath {
 }
 
 pub struct SearchFileContentClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl SearchFileContentClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/subprocess_spawned_output.rs
+++ b/sidecar/src/agentic/tool/lsp/subprocess_spawned_output.rs
@@ -1,6 +1,7 @@
 //! This grabs all the pending output if any from the subprocess which have been spawned
 
 use async_trait::async_trait;
+use logging::new_client;
 
 use crate::agentic::tool::{
     errors::ToolError,
@@ -38,13 +39,13 @@ impl SubProcessSpanwedPendingOutputResponse {
 }
 
 pub struct SubProcessSpawnedPendingOutputClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl SubProcessSpawnedPendingOutputClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/lsp/undo_changes.rs
+++ b/sidecar/src/agentic/tool/lsp/undo_changes.rs
@@ -2,6 +2,7 @@
 //! We have access to a session and exchange and the plan step
 
 use async_trait::async_trait;
+use logging::new_client;
 
 use crate::agentic::tool::{
     errors::ToolError,
@@ -47,13 +48,13 @@ impl UndoChangesMadeDuringExchangeRespnose {
 }
 
 pub struct UndoChangesMadeDuringExchange {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl UndoChangesMadeDuringExchange {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/session/exchange.rs
+++ b/sidecar/src/agentic/tool/session/exchange.rs
@@ -2,6 +2,7 @@
 //! agent to send replies, followings etc
 
 use async_trait::async_trait;
+use logging::new_client;
 
 use crate::agentic::tool::{
     errors::ToolError,
@@ -37,13 +38,13 @@ impl SessionExchangeNewResponse {
 }
 
 pub struct SessionExchangeClient {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl SessionExchangeClient {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/swe_bench/test_tool.rs
+++ b/sidecar/src/agentic/tool/swe_bench/test_tool.rs
@@ -7,6 +7,7 @@ use crate::agentic::tool::{
     r#type::{Tool, ToolRewardScale},
 };
 use async_trait::async_trait;
+use logging::new_client;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SWEBenchTestRequest {
@@ -38,13 +39,13 @@ impl SWEBenchTestRepsonse {
 }
 
 pub struct SWEBenchTestTool {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl SWEBenchTestTool {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }

--- a/sidecar/src/agentic/tool/terminal/terminal.rs
+++ b/sidecar/src/agentic/tool/terminal/terminal.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use logging::new_client;
 
 use crate::agentic::tool::{
     errors::ToolError,
@@ -8,7 +9,7 @@ use crate::agentic::tool::{
 };
 
 pub struct TerminalTool {
-    client: reqwest::Client,
+    client: reqwest_middleware::ClientWithMiddleware,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -112,7 +113,7 @@ impl TerminalOutput {
 impl TerminalTool {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: new_client(),
         }
     }
 }


### PR DESCRIPTION
I understand this might be seen as unnecessary complexity, so feel free to ignore!

This PR adds an optional compile-time feature `tee_requests` that tees all HTTP requests to another server. By default this server is `http://localhost:8080`, though it can also be overridden by the env var `AIDE_TEE_URL`.

I'm kind of tempted to remove the compile time flag and the default and just send requests any time the env var is set, it seems simpler, but I thought maybe people would want this to interfere with normal program flow as little as possible (maybe I could also cache the env var value, though the overhead of reading an env var in rust is measured in nanoseconds).

This functionality can be used to debug or aid understanding the flow of requests between sidecar/IDE/LLM provider.

Note: no responses are logged here, only requests. I originally had some code that copied the bytes of the LLM responses and logged it in the middleware, but collecting the bytes is a blocking operation. I therefore moved the response logging to the IDE TS code instead, where the code can collect lines for logging with each `yield` whilst handling the streaming response. I guess I could have done that here too, but it might be a bit messy, and the client seems a more logical place for it.

I've made each cargo dependency update command a separate commit, partly to make it easy to resolve merge conflicts in future, and partly to ensure I understand what I have changed. I could squish these if you prefer.

When both IDE and sidecar have this optional logging turned on, and requests are forwarded to mitm proxy, the mitm web UI looks like this:

![image](https://github.com/user-attachments/assets/1a916ff7-54fe-49d7-a7ba-3dbb3d259678)

Though I'm using mitm proxy to collect requests, it's not actually being used as a proxy - the requests will all fail with "Connection killed: Request destination unknown". The only reason I'm using it is because it provides a nice UI for filtering, searching, saving and loading requests. Any type of server that collects everything sent to it for analysis would work.