### PR TITLE
Disambiguate non-blocking terminal commands

### DIFF
--- a/sidecar/src/agentic/symbol/tool_box.rs
+++ b/sidecar/src/agentic/symbol/tool_box.rs
@@ -5921,11 +5921,13 @@ FILEPATH: {fs_file_path}
     pub async fn use_terminal_command(
         &self,
         command: &str,
+        wait_for_exit: bool,
         message_properties: SymbolEventMessageProperties,
     ) -> Result<TerminalOutput, SymbolError> {
         let input = ToolInput::TerminalCommand(TerminalInput::new(
             command.to_owned(),
             message_properties.editor_url().to_owned(),
+            wait_for_exit.to_owned()
         ));
         self.tools
             .invoke(input)

--- a/sidecar/src/agentic/tool/session/session.rs
+++ b/sidecar/src/agentic/tool/session/session.rs
@@ -2723,7 +2723,8 @@ reason: {}"#,
             ToolInputPartial::TerminalCommand(terminal_command) => {
                 println!("terminal command: {}", terminal_command.command());
                 let command = terminal_command.command().to_owned();
-                let request = TerminalInput::new(command, message_properties.editor_url());
+                let wait_for_exit = terminal_command.wait_for_exit().to_owned();
+                let request = TerminalInput::new(command, message_properties.editor_url(), wait_for_exit);
                 let input = ToolInput::TerminalCommand(request);
                 let tool_output = tool_box
                     .tools()

--- a/sidecar/src/mcts/execution/inference.rs
+++ b/sidecar/src/mcts/execution/inference.rs
@@ -695,8 +695,9 @@ Always include the <thinking></thinking> section before using the tool."#
             }
             ToolInputPartial::TerminalCommand(terminal_command) => {
                 let command = terminal_command.command().to_owned();
+                let wait_for_exit = terminal_command.wait_for_exit().to_owned();
                 let request =
-                    TerminalInput::new(command.to_owned(), message_properties.editor_url());
+                    TerminalInput::new(command.to_owned(), message_properties.editor_url(), wait_for_exit.to_owned());
                 let input = ToolInput::TerminalCommand(request);
                 let tool_output = tool_box
                     .tools()


### PR DESCRIPTION
Currently, we have an arbitrary heuristic on the editor side to wait for 10 seconds for a terminal command to complete, and proceed to the next iteration. But I keep running into cases within the editor where this blows up. This PR makes the LLM share an additional `wait_for_exit` param for the `execute_command` tool call - which, if true, the editor returns only after the command run is complete. And if false, the editor returns instantly after running the command.

So far in my testing, this is working fine. My only concern here would be cases where the LLM decides to run a long-running command in the hope of evaluating whether the code compiles, for example. In such cases, the LLM would need to know the output of the command - even though the command didn't exit. For instance, when running `npm run dev`,
```sh
❯ npm run dev

> website@0.1.0 dev
> next dev

  ▲ Next.js 14.2.5
  - Local:        http://localhost:3000
  - Environments: .env

 ✓ Starting...
 ✓ Ready in 1428ms
```
this output is still handy to know that the code compiles (although this is not quite true - in NextJS, all the routes don't get built when running `npm run dev`. It's actually when the application is being run, and a problematic route is hit, does their build tool even compile and throw the error).

In my testing so far, the LLM goes ahead and assumes life is good after running `npm run dev`. If you've seen any other edge cases that might be a problem, we can look at some solutions to get this info over from the editor.

Editor PR: https://github.com/codestoryai/aide/pull/1134