### PR TITLE
Extremely WIP POC of web search using Exa search API

### DIFF
--- a/sidecar/src/agentic/tool/broker.rs
+++ b/sidecar/src/agentic/tool/broker.rs
@@ -73,6 +73,7 @@ use super::{
     swe_bench::test_tool::SWEBenchTestTool,
     terminal::terminal::TerminalTool,
     test_runner::runner::TestRunner,
+    web_search::web_search::WebSearchTool,
 };
 
 pub struct ToolBrokerConfiguration {
@@ -483,6 +484,10 @@ impl ToolBroker {
         tools.insert(
             ToolType::SemanticSearch,
             Box::new(SemanticSearch::new(llm_client)),
+        );
+        tools.insert(
+            ToolType::WebSearch,
+            Box::new(WebSearchTool::new()),
         );
         // we also want to add the re-ranking tool here, so we invoke it freely
         Self { tools }

--- a/sidecar/src/agentic/tool/input.rs
+++ b/sidecar/src/agentic/tool/input.rs
@@ -81,6 +81,7 @@ use super::{
     swe_bench::test_tool::SWEBenchTestRequest,
     terminal::terminal::{TerminalInput, TerminalInputPartial},
     test_runner::runner::{TestRunnerRequest, TestRunnerRequestPartial},
+    web_search::types::WebSearchRequest,
 };
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -98,6 +99,7 @@ pub enum ToolInputPartial {
     CodeEditorParameters(CodeEditorParameters),
     SemanticSearch(SemanticSearchParametersPartial),
     Reasoning(ToolUseAgentReasoningParamsPartial),
+    WebSearch(WebSearchRequest),
 }
 
 impl ToolInputPartial {
@@ -116,6 +118,7 @@ impl ToolInputPartial {
             Self::CodeEditorParameters(_) => ToolType::CodeEditorTool,
             Self::SemanticSearch(_) => ToolType::SemanticSearch,
             Self::Reasoning(_) => ToolType::Reasoning,
+            Self::WebSearch(_) => ToolType::WebSearch,
         }
     }
 
@@ -140,6 +143,7 @@ impl ToolInputPartial {
                 semantic_search_parameters.to_string()
             }
             Self::Reasoning(tool_use_reasoning) => tool_use_reasoning.to_string(),
+            Self::WebSearch(web_search) => web_search.to_string(),
         }
     }
 
@@ -172,6 +176,7 @@ impl ToolInputPartial {
                 serde_json::to_value(semantic_search_parameters).ok()
             }
             Self::Reasoning(reasoning_input) => serde_json::to_value(reasoning_input).ok(),
+            Self::WebSearch(request) => serde_json::to_value(request).ok(),
         }
     }
 
@@ -188,6 +193,7 @@ impl ToolInputPartial {
             ToolType::RepoMapGeneration => None,
             ToolType::TestRunner => Some(TestRunnerRequestPartial::to_json()),
             ToolType::CodeEditorTool => Some(CodeEditorParameters::to_json()),
+            ToolType::WebSearch => Some(WebSearchRequest::to_json()),
             _ => None,
         }
     }
@@ -317,6 +323,8 @@ pub enum ToolInput {
     FeedbackGeneration(FeedbackGenerationRequest),
     // Semantic search input
     SemanticSearch(SemanticSearchRequest),
+    // Web search input
+    WebSearch(WebSearchRequest),
 }
 
 impl ToolInput {
@@ -406,6 +414,7 @@ impl ToolInput {
             ToolInput::RunTests(_) => ToolType::TestRunner,
             ToolInput::RewardGeneration(_) => ToolType::RewardGeneration,
             ToolInput::FeedbackGeneration(_) => ToolType::FeedbackGeneration,
+            ToolInput::WebSearch(_) => ToolType::WebSearch,
         }
     }
 
@@ -1148,6 +1157,16 @@ impl ToolInput {
             Ok(terminal_command)
         } else {
             Err(ToolError::WrongToolInput(ToolType::TerminalCommand))
+        }
+    }
+
+    pub fn is_web_search(self) -> Result<WebSearchRequest, ToolError> {
+        if let ToolInput::WebSearchRequest(request) = self {
+            Ok(request)
+        } else {
+            Err(ToolError::WrongToolInput(
+                ToolType::WebSearch,
+            ))
         }
     }
 }

--- a/sidecar/src/agentic/tool/mod.rs
+++ b/sidecar/src/agentic/tool/mod.rs
@@ -41,4 +41,5 @@ pub mod session;
 pub mod swe_bench;
 pub mod terminal;
 pub mod test_runner;
+pub mod web_search;
 pub mod r#type;

--- a/sidecar/src/agentic/tool/output.rs
+++ b/sidecar/src/agentic/tool/output.rs
@@ -1,6 +1,6 @@
 //! Contains the output of a tool which can be used by any of the callers
 
-use crate::agentic::symbol::ui_event::RelevantReference;
+use crate::agentic::{symbol::ui_event::RelevantReference, tool::web_search::types::WebSearchResponse};
 
 use super::{
     code_edit::{
@@ -228,6 +228,8 @@ pub enum ToolOutput {
     FeedbackGeneration(FeedbackGenerationResponse),
     // Semantic search file level response
     SemanticSearch(SemanticSearchResponse),
+    // Web search response
+    WebSearch(WebSearchResponse),
 }
 
 impl ToolOutput {
@@ -439,6 +441,10 @@ impl ToolOutput {
             ToolOutput::EditorApplyChanges(output) => Some(output),
             _ => None,
         }
+    }
+
+    pub fn web_search(response: WebSearchResponse) -> Self {
+        ToolOutput::WebSearch(response)
     }
 
     /// Grabs the output of filter edit operations from the ToolOutput
@@ -893,6 +899,13 @@ impl ToolOutput {
     pub fn get_semantic_search_response(self) -> Option<SemanticSearchResponse> {
         match self {
             ToolOutput::SemanticSearch(response) => Some(response),
+            _ => None,
+        }
+    }
+
+    pub fn get_web_search_response(self) -> Option<WebSearchResponse> {
+        match self {
+            ToolOutput::WebSearch(response) => Some(response),
             _ => None,
         }
     }

--- a/sidecar/src/agentic/tool/session/session.rs
+++ b/sidecar/src/agentic/tool/session/session.rs
@@ -2805,6 +2805,53 @@ reason: {}"#,
                     exchange_id.to_owned(),
                 );
             }
+            ToolInputPartial::WebSearch(_web_search) => {
+                todo!("todo!")
+                // let request = SearchFileContentInput::new(
+                //     search_file.directory_path().to_owned(),
+                //     search_file.regex_pattern().to_owned(),
+                //     search_file.file_pattern().map(|s| s.to_owned()),
+                //     message_properties.editor_url(),
+                // );
+                // let input = ToolInput::SearchFileContentWithRegex(request);
+                // let response = tool_box
+                //     .tools()
+                //     .invoke(input)
+                //     .await
+                //     .map_err(|e| SymbolError::ToolError(e))?
+                //     .get_search_file_content_with_regex()
+                //     .ok_or(SymbolError::WrongToolOutput)?;
+
+                // let response = response.response();
+
+                // // we have the tool output over here
+                // if let Some(action_node) = self.action_nodes.last_mut() {
+                //     action_node.add_observation_mut(response.to_owned());
+                //     action_node.set_time_taken_seconds(tool_use_time_taken.elapsed().as_secs_f32());
+                // }
+
+                // // if the cancellation token is set, then we should not update
+                // // our state over here with the broken terminal output
+                // if message_properties.cancellation_token().is_cancelled() {
+                //     return Ok(self);
+                // }
+                // let _ =
+                //     message_properties
+                //         .ui_sender()
+                //         .send(UIEventWithID::tool_output_delta_response(
+                //             message_properties.root_request_id().to_owned(),
+                //             message_properties.request_id_str().to_owned(),
+                //             "".to_owned(),
+                //             response.to_owned(),
+                //         ));
+                // self = self.tool_output(
+                //     &exchange_id,
+                //     tool_type.clone(),
+                //     response.to_owned(),
+                //     UserContext::default(),
+                //     exchange_id.to_owned(),
+                // );
+            }
             ToolInputPartial::CodeEditorParameters(_code_editor_parameters) => {
                 // we do not use this tool via the session.invoke_tool flow at all
             }

--- a/sidecar/src/agentic/tool/type.rs
+++ b/sidecar/src/agentic/tool/type.rs
@@ -152,6 +152,8 @@ pub enum ToolType {
     FeedbackGeneration,
     // Code editor tool (this is special for anthropic)
     CodeEditorTool,
+    // Search the web
+    WebSearch,
 }
 
 impl std::fmt::Display for ToolType {

--- a/sidecar/src/agentic/tool/web_search/cache.rs
+++ b/sidecar/src/agentic/tool/web_search/cache.rs
@@ -1,0 +1,72 @@
+/*
+Thread-safe in-memory cache, with optional disk persistence
+
+Writing to disk is just for debugging and to avoid using up the free API quota, not for production use
+*/
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::path::Path;
+use std::fs;
+use anyhow;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub(crate) struct CachedResponse {
+    pub response: String,
+    pub timestamp: u64,
+}
+
+pub(crate) struct WebSearchCache {
+    inner: Arc<RwLock<HashMap<String, CachedResponse>>>,
+    cache_file: Option<String>,
+}
+
+impl WebSearchCache {
+    pub fn new() -> Self {
+        WebSearchCache {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            cache_file: None,
+        }
+    }
+
+    pub fn with_cache_file<P: AsRef<Path>>(cache_file: P) -> Self {
+        let cache_path = cache_file.as_ref().to_string_lossy().to_string();
+        let mut cache = Self::new();
+        cache.cache_file = Some(cache_path.clone());
+
+        // Try to load existing cache
+        if let Ok(contents) = fs::read_to_string(&cache_path) {
+            if let Ok(map) = serde_json::from_str(&contents) {
+                cache.inner = Arc::new(RwLock::new(map));
+            }
+        }
+
+        cache
+    }
+
+    pub fn set(&self, key: String, value: CachedResponse) {
+        let _old_value = self.inner.write().unwrap().insert(key, value);
+    }
+
+    pub fn get(&self, key: &str) -> Option<CachedResponse> {
+        self.inner.read().unwrap().get(key).cloned()
+    }
+
+    pub fn save_to_disk(&self) -> Result<(), anyhow::Error> {
+        if let Some(cache_file) = &self.cache_file {
+            let guard = self.inner.read().map_err(|e| anyhow::anyhow!("Failed to acquire read lock: {}", e))?;
+            let serialized = serde_json::to_string(&*guard)?;
+            fs::write(cache_file, serialized)?;
+        }
+        Ok(())
+    }
+}
+
+impl Clone for WebSearchCache {
+    fn clone(&self) -> Self {
+        WebSearchCache {
+            inner: Arc::clone(&self.inner),
+            cache_file: self.cache_file.clone(),
+        }
+    }
+}

--- a/sidecar/src/agentic/tool/web_search/exa.rs
+++ b/sidecar/src/agentic/tool/web_search/exa.rs
@@ -1,0 +1,86 @@
+use std::env;
+use logging::new_client;
+use anyhow::Result;
+
+use super::types::WebSearchRequest;
+
+#[derive(serde::Serialize, Debug, Clone)]
+pub(crate) struct Summary {
+    query: Option<String>,
+}
+
+#[derive(serde::Serialize, Debug, Clone)]
+pub(crate) struct Contents {
+    text: bool,
+    summary: Summary,
+    // There are  other options, see the Exa API documentation
+}
+
+#[derive(serde::Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ExaSearchRequest {
+    pub query: String,
+    pub num_results: i32,
+    pub contents: Contents,
+    pub r#type: String,
+    // There are many other options, see the Exa API documentation
+}
+
+// * TODO hard coded some of the parameters for now,
+// maybe the agent should be free to change them?
+// or at least extract the defaults into a struct...
+impl From<WebSearchRequest> for ExaSearchRequest {
+    fn from(request: WebSearchRequest) -> Self {
+        Self {
+            query: request.query,
+            num_results: 3,
+            r#type: "keyword".to_string(),
+            contents: Contents {
+                text: false,
+                summary: Summary {
+                    query: None
+                },
+            },
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ExaClient {
+    client: reqwest_middleware::ClientWithMiddleware,
+}
+
+impl ExaClient {
+    const API_URL: &'static str = "https://api.exa.ai/search";
+
+    pub fn new() -> Self {
+        Self {
+            client: new_client(),
+        }
+    }
+
+    // TODO should requests be proxied by a CodeStory server with
+    // an API key?
+    // Or should search API key come from the IDE config?
+    fn api_key(&self) -> Result<String, anyhow::Error> {
+        env::var("AIDE_EXA_API_KEY")
+        .map_err(|_| anyhow::anyhow!("Missing AIDE_EXA_API_KEY"))
+    }
+
+    pub async fn perform_web_search(
+        &self,
+        request: ExaSearchRequest,
+    ) -> Result<String> {
+        let access_token = self.api_key()?;
+
+        let response = self
+            .client
+            .post(Self::API_URL)
+            .header("x-api-key", access_token)
+            .json(&request)
+            .send()
+            .await?;
+
+        Ok(response.text().await?)
+    }
+}

--- a/sidecar/src/agentic/tool/web_search/mod.rs
+++ b/sidecar/src/agentic/tool/web_search/mod.rs
@@ -1,0 +1,5 @@
+pub mod cache;
+pub mod exa;
+pub mod rate_limit;
+pub mod web_search;
+pub mod types;

--- a/sidecar/src/agentic/tool/web_search/rate_limit.rs
+++ b/sidecar/src/agentic/tool/web_search/rate_limit.rs
@@ -1,0 +1,52 @@
+/*
+Prevent run-away loops from generating huge numbers of requests
+
+TODO: is this actually necessary?
+*/
+
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+
+const RATE_LIMIT_PER_SECOND: u32 = 1;
+
+// TODO use a specific error type
+pub fn check_rate_limit() -> Result<(), anyhow::Error> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+
+    let mut count = REQUEST_COUNT.lock().map_err(|_| anyhow::anyhow!("Failed to acquire lock"))?;
+
+    if now - count.last_reset > 1000 {
+        count.second = 0;
+        count.last_reset = now;
+    }
+
+    if count.second >= RATE_LIMIT_PER_SECOND {
+        return Err(anyhow::anyhow!("Rate limit exceeded"));
+    }
+
+    count.second += 1;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct RequestCount {
+    second: u32,
+    last_reset: u128,
+}
+
+impl RequestCount {
+    fn new() -> Self {
+        Self {
+            second: 0,
+            last_reset: 0,
+        }
+    }
+}
+
+lazy_static! {
+    static ref REQUEST_COUNT: Mutex<RequestCount> = Mutex::new(RequestCount::new());
+}

--- a/sidecar/src/agentic/tool/web_search/types.rs
+++ b/sidecar/src/agentic/tool/web_search/types.rs
@@ -1,0 +1,23 @@
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WebSearchRequest {
+    pub query: String
+}
+
+impl WebSearchRequest {
+    pub fn web_search_as_string(query: &str) -> String {
+        return format!("<web_search>
+<query>
+{query}
+</query>
+</web_search>");
+    }
+
+    pub fn to_string(&self) -> String {
+        Self::web_search_as_string(&self.query)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WebSearchResponse {
+    pub summaries: Vec<String>,
+}

--- a/sidecar/src/agentic/tool/web_search/web_search.rs
+++ b/sidecar/src/agentic/tool/web_search/web_search.rs
@@ -1,0 +1,104 @@
+use axum::async_trait;
+use crate::agentic::tool::{
+    errors::ToolError,
+    input::ToolInput,
+    output::ToolOutput,
+    r#type::{Tool, ToolRewardScale},
+    web_search::types::WebSearchRequest,
+};
+
+use super::{
+    cache::{CachedResponse, WebSearchCache},
+    exa::{ExaClient, ExaSearchRequest},
+    rate_limit::check_rate_limit, types::WebSearchResponse,
+};
+
+pub struct WebSearchTool {
+    exa_client: ExaClient,
+    cache: WebSearchCache,
+}
+
+impl WebSearchTool {
+    pub fn new() -> Self {
+        Self {
+            exa_client: ExaClient::new(),
+            cache: WebSearchCache::with_cache_file("cache.json"),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for WebSearchTool {
+    async fn invoke(&self, input: ToolInput) -> Result<ToolOutput, ToolError> {
+        let context = input.is_web_search()?;
+
+        // TODO: could hash this rather than use the query as the key ? Not sure it's worth it though
+        let cache_key = context.query;
+        let cached = self.cache.get(&cache_key);
+
+        if let Some(cached_value) = cached {
+            println!("Cache hit");
+            todo!("todo");
+            // TODO extract the summaries from the response JSON
+            return Ok(ToolOutput::web_search(
+                WebSearchResponse {
+                    summaries: vec!["TODO".to_string(); 3]
+                }
+            ));
+        }
+
+        check_rate_limit()?;
+
+        // * TODO the CLI program I wrote used a trait to make this code
+        //generic across multiple search APIs, but it's removed here
+        // as only one API is supported and KISS where possible
+        let search_request = ExaSearchRequest::from(context);
+        let text = self.exa_client.perform_web_search(search_request).await?;
+
+        let cached_response = CachedResponse {
+            response: text.clone(),
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        };
+        self.cache.set(cache_key, cached_response);
+
+        // TODO: remove caching to disk
+        // only keep in-memory cache, writing to disk is just
+        // for debugging and to avoid using up a free API quota
+        self.cache.save_to_disk()?;
+
+        // TODO extract the summaries from the response JSON
+        todo!("todo");
+        Ok(ToolOutput::web_search(
+        WebSearchResponse {
+                summaries: vec!["TODO".to_string(); 3]
+            }
+        ));
+    }
+
+    fn tool_description(&self) -> String {
+        format!(
+            r#"### web_search
+Request to perform a web search, providing up-to-date information from the internet in response to queries.
+Web searches are necessary for data that is missing or out-of-date in the LLM training set, but the returned summaries of web pages will not be directly tailored to the query."#
+        )
+    }
+
+    fn tool_input_format(&self) -> String {
+        format!(r#"Parameters:
+        - query: (required) A free text query to search the internet for.
+
+        Usage:
+        {}"#, WebSearchRequest::web_search_as_string("query here"))
+    }
+
+    fn get_evaluation_criteria(&self, _trajectory_length: usize) -> Vec<String> {
+        vec![]
+    }
+
+    fn get_reward_scale(&self, _trajectory_length: usize) -> Vec<ToolRewardScale> {
+        vec![]
+    }
+}

--- a/sidecar/src/mcts/execution/inference.rs
+++ b/sidecar/src/mcts/execution/inference.rs
@@ -735,7 +735,7 @@ Terminal output: {}"#,
                 let message = format!(
                     r#"Here's the result of running the tests on the following files:
 {}
-                
+
 Test Output from the script (we also have to setup the test runner):
 Exit code: {}
 Output:
@@ -763,6 +763,10 @@ Output:
                         false,
                     )),
                 }
+            },
+            ToolInputPartial::WebSearch(_web_search) => {
+                // TODO: does this actually need an implementation?
+                todo!("web search is not supported with MCTS inference, is this dead code?")
             }
         }
     }


### PR DESCRIPTION
This PR adds most of the scaffolding for a new agentic tool to use the Exa web search API.

In this PR, the Exa API is asked to provide a text summary of each page in the results (which they produce using their own LLM). 

The Exa API has lots of options besides summarization (e.g. categorization, highlights, full page content, and custom summarization queries). The initial theory of this implementation is that the summaries functionality could work well, using summaries from the top 3 results formatted to be consumed by the agent, but it would be good to experiment with some of the other options.

This PR doesn't even compile right now, let alone run successfully. I know there are currently many errors that I need to fix if this is ever to be merged. I'm not even sure I will continue with this, just thought I'd show what I've got.

Besides fixing errors, there are also lots of design questions that would need more thought if this were to be production ready:


-> should web searches be proxied via a CodeStory server that maintains the API key and handles billing, or should the API key be managed by the Aide settings? Currently the key is just read from an env var

-> if the API key is to be managed by users in the IDE, then maybe web search should be exposed as an MCP server by the IDE, and shouldn't be a custom tool in the sidecar codebase at all?

-> is Exa actually the best API to use? There's also the Brave Search API, though it's automatic summarization features seem much more limited. I guess with Brave the web contents could be downloaded + converted to text + summarized by DeepSeek, rather than paying Exa to do it. Or maybe an altogether different approach would be better...

-> how to best format the tool description and system message to ensure the agent uses the tool appropriately?

-> experimentation with all the parameters provided by the Exa API (https://docs.exa.ai/reference/search), maybe summaries aren't the best functionality to use, or maybe there should be a custom summarization query, or maybe it should use neural search or similarity search, etc

Separate to this PR, I also created a Rust CLI tool for exploring both the Exa API and the Brave Search API, though it currently exposes only a limited subset of parameters:

https://github.com/treefrog00/rust-playground/tree/main/web-search-cli

