### PR TITLE
Continuing with MCP initialization based on darinkishore's PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3192,6 +3192,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mcp_client_rs"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "392ca22c7b117e3d1b8502d24b14727ac5cc764b12383d9561a82b2141ccb2b3"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4646,9 +4662,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -4772,6 +4788,7 @@ dependencies = [
  "llm_client",
  "llm_prompts",
  "logging",
+ "mcp_client_rs",
  "memchr",
  "ndarray",
  "nix",

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -103,6 +103,7 @@ dirs = "5.0.1"
 diffy = "0.4.0"
 colored = "2.1.0"
 reqwest-middleware = "0.4.0"
+mcp_client_rs = "0.1.7"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26.2", default-features = false, features = [ "resource" ] }

--- a/sidecar/src/agentic/symbol/tool_box.rs
+++ b/sidecar/src/agentic/symbol/tool_box.rs
@@ -105,7 +105,7 @@ use crate::agentic::tool::plan::add_steps::PlanAddRequest;
 use crate::agentic::tool::plan::generator::{StepGeneratorRequest, StepSenderEvent};
 use crate::agentic::tool::plan::plan_step::PlanStep;
 use crate::agentic::tool::plan::reasoning::ReasoningRequest;
-use crate::agentic::tool::r#type::Tool;
+use crate::agentic::tool::r#type::{Tool, ToolType};
 use crate::agentic::tool::ref_filter::ref_filter::ReferenceFilterRequest;
 use crate::agentic::tool::session::chat::SessionChatMessage;
 use crate::agentic::tool::session::exchange::SessionExchangeNewRequest;
@@ -159,6 +159,10 @@ impl ToolBox {
 
     pub fn tools(&self) -> Arc<ToolBroker> {
         self.tools.clone()
+    }
+
+    pub fn mcp_tools(&self) -> Box<[ToolType]> {
+        self.tools.mcp_tools.clone()
     }
 
     /// sends the user query to the scratch-pad agent

--- a/sidecar/src/agentic/tool/broker.rs
+++ b/sidecar/src/agentic/tool/broker.rs
@@ -495,15 +495,13 @@ impl ToolBroker {
 
         let mut mcp_tools = Vec::new();
 
-        if !cfg!(test) {
-            for tool in discover_mcp_tools().await.unwrap_or_else(|e| {
-                error!("Failed to discover MCP tools: {}", e);
-                Vec::new()
-            }) {
-                let tool_type = ToolType::McpTool(tool.full_name.clone());
-                tools.insert(tool_type.clone(), Box::new(tool));
-                mcp_tools.push(tool_type);
-            }
+        for tool in discover_mcp_tools().await.unwrap_or_else(|e| {
+            error!("Failed to discover MCP tools: {}", e);
+            Vec::new()
+        }) {
+            let tool_type = ToolType::McpTool(tool.full_name.clone());
+            tools.insert(tool_type.clone(), Box::new(tool));
+            mcp_tools.push(tool_type);
         }
 
         // we also want to add the re-ranking tool here, so we invoke it freely

--- a/sidecar/src/agentic/tool/broker.rs
+++ b/sidecar/src/agentic/tool/broker.rs
@@ -1,12 +1,11 @@
-use async_trait::async_trait;
-use std::{collections::HashMap, sync::Arc};
-
-use llm_client::broker::LLMBroker;
-
 use crate::{
     agentic::symbol::identifier::LLMProperties, chunking::languages::TSLanguageParsing,
     inline_completion::symbols_tracker::SymbolTrackerInline,
 };
+use async_trait::async_trait;
+use llm_client::broker::LLMBroker;
+use std::{collections::HashMap, sync::Arc};
+use tracing::error;
 
 use super::{
     code_edit::{
@@ -56,6 +55,7 @@ use super::{
         subprocess_spawned_output::SubProcessSpawnedPendingOutputClient,
         undo_changes::UndoChangesMadeDuringExchange,
     },
+    mcp::init::discover_mcp_tools,
     output::ToolOutput,
     plan::{
         add_steps::PlanAddStepClient, generator::StepGeneratorClient, reasoning::ReasoningClient,
@@ -96,10 +96,11 @@ impl ToolBrokerConfiguration {
 // sure that we do not store everything about the tool but a representation of it
 pub struct ToolBroker {
     tools: HashMap<ToolType, Box<dyn Tool + Send + Sync>>,
+    pub mcp_tools: Box<[ToolType]>,
 }
 
 impl ToolBroker {
-    pub fn new(
+    pub async fn new(
         llm_client: Arc<LLMBroker>,
         code_edit_broker: Arc<CodeEditBroker>,
         symbol_tracking: Arc<SymbolTrackerInline>,
@@ -491,8 +492,25 @@ impl ToolBroker {
             ToolType::RequestScreenshot,
             Box::new(RequestScreenshot::new()),
         );
+
+        let mut mcp_tools = Vec::new();
+
+        if !cfg!(test) {
+            for tool in discover_mcp_tools().await.unwrap_or_else(|e| {
+                error!("Failed to discover MCP tools: {}", e);
+                Vec::new()
+            }) {
+                let tool_type = ToolType::McpTool(tool.full_name.clone());
+                tools.insert(tool_type.clone(), Box::new(tool));
+                mcp_tools.push(tool_type);
+            }
+        }
+
         // we also want to add the re-ranking tool here, so we invoke it freely
-        Self { tools }
+        Self {
+            tools,
+            mcp_tools: mcp_tools.into_boxed_slice(),
+        }
     }
 
     /// Sets a reminder for the tool, including the name and the format of it

--- a/sidecar/src/agentic/tool/errors.rs
+++ b/sidecar/src/agentic/tool/errors.rs
@@ -91,4 +91,10 @@ pub enum ToolError {
 
     #[error("Cancelled by user")]
     UserCancellation,
+
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
+    #[error("Invocation error: {0}")]
+    InvocationError(String),
 }

--- a/sidecar/src/agentic/tool/input.rs
+++ b/sidecar/src/agentic/tool/input.rs
@@ -64,6 +64,7 @@ use super::{
         subprocess_spawned_output::SubProcessSpawnedPendingOutputRequest,
         undo_changes::UndoChangesMadeDuringExchangeRequest,
     },
+    mcp::input::{McpToolInput, McpToolPartial},
     plan::{
         add_steps::PlanAddRequest, generator::StepGeneratorRequest, reasoning::ReasoningRequest,
         updater::PlanUpdateRequest,
@@ -102,6 +103,7 @@ pub enum ToolInputPartial {
     Reasoning(ToolUseAgentReasoningParamsPartial),
     FindFile(FindFileInputPartial),
     RequestScreenshot(RequestScreenshotInputPartial),
+    McpTool(McpToolPartial),
 }
 
 impl ToolInputPartial {
@@ -122,6 +124,7 @@ impl ToolInputPartial {
             Self::Reasoning(_) => ToolType::Reasoning,
             Self::FindFile(_) => ToolType::FindFiles,
             Self::RequestScreenshot(_) => ToolType::RequestScreenshot,
+            Self::McpTool(partial) => ToolType::McpTool(partial.full_name.clone()),
         }
     }
 
@@ -148,6 +151,7 @@ impl ToolInputPartial {
             Self::Reasoning(tool_use_reasoning) => tool_use_reasoning.to_string(),
             Self::FindFile(find_file_partial_input) => find_file_partial_input.to_string(),
             Self::RequestScreenshot(request_screenshot) => request_screenshot.to_string(),
+            Self::McpTool(mcp_partial) => mcp_partial.to_string(),
         }
     }
 
@@ -184,6 +188,7 @@ impl ToolInputPartial {
             Self::RequestScreenshot(request_screenshot) => {
                 serde_json::to_value(request_screenshot).ok()
             }
+            Self::McpTool(mcp_partial) => serde_json::to_value(mcp_partial).ok(),
         }
     }
 
@@ -201,6 +206,7 @@ impl ToolInputPartial {
             ToolType::TestRunner => Some(TestRunnerRequestPartial::to_json()),
             ToolType::CodeEditorTool => Some(CodeEditorParameters::to_json()),
             ToolType::RequestScreenshot => Some(RequestScreenshotInputPartial::to_json()),
+            ToolType::McpTool(_name) => None,
             _ => None,
         }
     }
@@ -334,6 +340,8 @@ pub enum ToolInput {
     FindFiles(FindFilesRequest),
     // Request screenshot input
     RequestScreenshot(RequestScreenshotInput),
+    // Model Context Protocol tool
+    McpTool(McpToolInput),
 }
 
 impl ToolInput {
@@ -425,6 +433,7 @@ impl ToolInput {
             ToolInput::FeedbackGeneration(_) => ToolType::FeedbackGeneration,
             ToolInput::FindFiles(_) => ToolType::FindFiles,
             ToolInput::RequestScreenshot(_) => ToolType::RequestScreenshot,
+            ToolInput::McpTool(inp) => ToolType::McpTool(inp.partial.full_name.clone()),
         }
     }
 

--- a/sidecar/src/agentic/tool/mcp/config.json.example
+++ b/sidecar/src/agentic/tool/mcp/config.json.example
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "time": {
+      "command": "uvx",
+      "args": ["mcp-server-time"]
+    }
+  }
+}

--- a/sidecar/src/agentic/tool/mcp/init.rs
+++ b/sidecar/src/agentic/tool/mcp/init.rs
@@ -1,0 +1,123 @@
+use super::integration_tool::McpTool;
+use mcp_client_rs::client::Client;
+use mcp_client_rs::client::ClientBuilder;
+use serde::Deserialize;
+use std::{collections::HashMap, sync::Arc};
+use thiserror::Error;
+
+// Minimal code for MCP client spawner
+#[derive(Deserialize)]
+struct ServerConfig {
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: HashMap<String, String>,
+}
+
+#[derive(Deserialize)]
+pub struct RootConfig {
+    #[serde(rename = "mcpServers")]
+    mcp_servers: HashMap<String, ServerConfig>,
+}
+
+#[derive(Error, Debug)]
+pub enum McpError {
+    #[error("Could not determine home directory")]
+    NoHomeDir,
+
+    #[error("Failed to read config file: {0}")]
+    ConfigReadError(#[from] std::io::Error),
+
+    #[error("Failed to parse config file: {0}")]
+    ConfigParseError(#[from] serde_json::Error),
+
+    #[error("Failed listing tools from server '{server}': {source}")]
+    ToolListError {
+        server: String,
+        source: mcp_client_rs::Error,
+    },
+}
+
+/// Set up MCP clients by reading ~/.aide/config.json, spawning each server,
+/// and returning a HashMap<server_name -> Arc<Client>>.
+/// spawn a single MCP process per server, share references.
+async fn setup_mcp_clients() -> Result<HashMap<String, Arc<Client>>, McpError> {
+    let config_path = dirs::home_dir()
+        .ok_or(McpError::NoHomeDir)?
+        .join(".aide/config.json");
+
+    if !config_path.exists() {
+        return Ok(HashMap::new());
+    }
+
+    let config_str = tokio::fs::read_to_string(&config_path).await?;
+    let root_config: RootConfig = serde_json::from_str(&config_str)?;
+
+    let mut mcp_clients_map = HashMap::new();
+
+    // For each server in the config, spawn an MCP client
+    for (server_name, server_conf) in &root_config.mcp_servers {
+        let mut builder = ClientBuilder::new(&server_conf.command);
+        for arg in &server_conf.args {
+            builder = builder.arg(arg);
+        }
+        for (k, v) in &server_conf.env {
+            builder = builder.env(k, v);
+        }
+
+        match builder.spawn_and_initialize().await {
+            Ok(client) => {
+                let client_arc = Arc::new(client);
+                mcp_clients_map.insert(server_name.clone(), client_arc);
+                eprintln!("Initialized MCP client for '{}'", server_name);
+            }
+            Err(e) => {
+                eprintln!(
+                    "Failed to initialize MCP client for '{}': {}",
+                    server_name, e
+                );
+                // keep trying other clients
+            }
+        }
+    }
+
+    Ok(mcp_clients_map)
+}
+
+/// discover each MCP server in ~/.aide/config.json
+/// create dynamic tools from each server
+/// used to augument broker initialization w/MCP tools
+pub async fn discover_mcp_tools() -> Result<Vec<McpTool>, McpError> {
+    let clients = setup_mcp_clients().await?;
+    if clients.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut tools: Vec<McpTool> = Vec::new();
+
+    for (server_name, client) in clients {
+        let list_res = client
+            .list_tools()
+            .await
+            .map_err(|e| McpError::ToolListError {
+                server: server_name.clone(),
+                source: e,
+            })?;
+
+        for tool_info in list_res.tools {
+            let name = tool_info.name;
+            let tool: McpTool = McpTool::new(
+                server_name.clone(),
+                name.clone(),
+                tool_info.description,
+                tool_info.input_schema,
+                Arc::clone(&client),
+            );
+
+            tools.push(tool);
+        }
+    }
+
+    Ok(tools)
+}

--- a/sidecar/src/agentic/tool/mcp/input.rs
+++ b/sidecar/src/agentic/tool/mcp/input.rs
@@ -1,0 +1,31 @@
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct McpToolPartial {
+    /// The normalized name including mcp prefix, e.g. "mcp::notes_server::add_note"
+    pub full_name: String,
+    /// A JSON object from the LLM
+    pub json: serde_json::Map<String, serde_json::Value>,
+}
+
+impl McpToolPartial {
+    pub fn to_string(&self) -> String {
+        format!(
+            r#"<{}>
+{}
+</{}>"#,
+            self.full_name,
+            serde_json::to_string_pretty(&self.json).unwrap_or_default(),
+            self.full_name
+        )
+    }
+
+    pub fn parse(full_name: &str, json_str: &str) -> Result<Self, serde_json::Error> {
+        let json: serde_json::Map<String, serde_json::Value> = serde_json::from_str(json_str)?;
+        let full_name = full_name.to_string();
+        Ok(Self { full_name, json })
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct McpToolInput {
+    pub partial: McpToolPartial,
+}

--- a/sidecar/src/agentic/tool/mcp/integration_tool.rs
+++ b/sidecar/src/agentic/tool/mcp/integration_tool.rs
@@ -1,0 +1,316 @@
+use async_trait::async_trait;
+use mcp_client_rs::client::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Arc;
+
+use crate::agentic::tool::{
+    errors::ToolError,
+    input::ToolInput,
+    output::ToolOutput,
+    r#type::{Tool, ToolRewardScale, ToolType},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDescriptor {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub schema: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerTools {
+    pub server_name: String,
+    pub tools: Vec<ToolDescriptor>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolListResponse {
+    pub servers: Vec<ServerTools>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpToolResponse {
+    pub data: Value,
+}
+
+/// example, if the server "notes_server" has a tool
+/// "add-note", the broker will store
+///    ToolType::McpTool("mcp::notes_server::add_note")
+/// -> McpTool { full_name: "mcp::notes_server::add_note", server_name: "notes_server", original_name: "add-note", ... }
+pub struct McpTool {
+    pub full_name: String,
+    server_name: String,
+    original_tool_name: String,
+    description: String,
+    schema: Value,
+    client: Arc<Client>,
+    // client is Arc because we want to share it across multiple tools for the same server
+}
+
+impl McpTool {
+    pub fn new(
+        server_name: String,
+        tool_name: String,
+        description: String,
+        schema: Value,
+        client: Arc<Client>,
+    ) -> Self {
+        // full name creation:
+        // * mcp:: prefix
+        // * lower case names, and replace hyphens with underscore
+        // * join server name and tool name with ::
+
+        let server_name_normalized = server_name.to_lowercase().replace('-', "_");
+        let tool_name_normalized = tool_name.to_lowercase().replace('-', "_");
+        let full_name = format!("mcp::{}::{}", server_name_normalized, tool_name_normalized);
+
+        Self {
+            full_name,
+            server_name,
+            original_tool_name: tool_name,
+            description,
+            schema,
+            client,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for McpTool {
+    async fn invoke(&self, input: ToolInput) -> Result<ToolOutput, ToolError> {
+        let input = match input {
+            ToolInput::McpTool(p) => p,
+            _ => {
+                return Err(ToolError::WrongToolInput(ToolType::McpTool(
+                    self.full_name.clone(),
+                )))
+            }
+        };
+
+        // Check for mismatch:
+        if input.partial.full_name != self.full_name {
+            return Err(ToolError::InvalidInput(format!(
+                "McpTool mismatch: local tool='{}' but input='{}'",
+                self.full_name, input.partial.full_name
+            )));
+        }
+
+        let arguments = Value::Object(input.partial.json);
+
+        // Perform the call
+        let result = self
+            .client
+            .call_tool(&self.original_tool_name, arguments)
+            .await
+            .map_err(|e| {
+                ToolError::InvocationError(format!(
+                    "Failed calling dynamic tool '{}' on server '{}': {}",
+                    self.full_name, self.server_name, e
+                ))
+            })?;
+
+        let value = serde_json::to_value(result).map_err(|e| {
+            ToolError::InvocationError(format!("Serialize dynamic tool result failed: {}", e))
+        })?;
+
+        // Return as typical
+        Ok(ToolOutput::McpTool(McpToolResponse { data: value }))
+    }
+
+    fn tool_description(&self) -> String {
+        format!("### {}\n{}", self.full_name, self.description)
+    }
+
+    fn tool_input_format(&self) -> String {
+        format!(
+            r#"Parameters:
+Provide all parameters as a JSON object. This object will be passed on to an MCP server, so it must be valid JSON, and it must match the schema below. This is the schema for the tool:
+
+{}
+
+Usage:
+
+For example, if the schema above included a "city" parameter, the tool might be called like this:
+
+<{}>
+{{
+  "city": "San Francisco"
+}}
+</{}>"#,
+            serde_json::to_string_pretty(&self.schema).unwrap_or_else(|_| self.schema.to_string()),
+            self.full_name,
+            self.full_name
+        )
+    }
+
+    fn get_evaluation_criteria(&self, _trajectory_length: usize) -> Vec<String> {
+        vec![]
+    }
+
+    fn get_reward_scale(&self, _trajectory_length: usize) -> Vec<ToolRewardScale> {
+        vec![]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agentic::tool::{
+        input::ToolInput, lsp::open_file::OpenFileRequest, mcp::input::McpToolInput,
+        mcp::input::McpToolPartial,
+    };
+    use lazy_static::lazy_static;
+    use mcp_client_rs::client::ClientBuilder;
+    use tokio;
+
+    lazy_static! {
+        static ref CONVERT_TIME_SCHEMA: serde_json::Value = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "source_timezone": {
+                    "type": "string",
+                    "description": "Source IANA timezone name (e.g., 'America/New_York', 'Europe/London'). Use '{local_tz}' as local timezone if no source timezone provided by the user.",
+                },
+                "time": {
+                    "type": "string",
+                    "description": "Time to convert in 24-hour format (HH:MM)",
+                },
+                "target_timezone": {
+                    "type": "string",
+                    "description": "Target IANA timezone name (e.g., 'Asia/Tokyo', 'America/San_Francisco'). Use '{local_tz}' as local timezone if no target timezone provided by the user.",
+                },
+            },
+            "required": ["source_timezone", "time", "target_timezone"],
+        });
+    }
+
+    async fn setup_test_client() -> anyhow::Result<Arc<Client>> {
+        let builder = ClientBuilder::new("uvx").arg("mcp-server-time");
+
+        let client = builder.spawn_and_initialize().await?;
+        Ok(Arc::new(client))
+    }
+
+    #[tokio::test]
+    async fn test_mcp_tool_creation() -> anyhow::Result<()> {
+        let client = setup_test_client().await?;
+
+        // List available tools
+        let list_res = client.list_tools().await?;
+        assert!(
+            !list_res.tools.is_empty(),
+            "Server should have at least one tool"
+        );
+
+        // Create McpTool for each tool
+        for tool_info in list_res.tools {
+            let mcp_tool = McpTool::new(
+                "time".to_string(),
+                tool_info.name.clone(),
+                tool_info.description.clone(),
+                tool_info.input_schema.clone(),
+                Arc::clone(&client),
+            );
+
+            // Test tool description and input format
+            let desc = mcp_tool.tool_description();
+            assert!(!desc.is_empty(), "Tool description should not be empty");
+
+            let input_format = mcp_tool.tool_input_format();
+            assert!(
+                !input_format.is_empty(),
+                "Tool input format should not be empty"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_mcp_tool_invocation() -> anyhow::Result<()> {
+        let client = setup_test_client().await?;
+
+        // Create a test note using the add_note tool
+        let json_str = r#"{
+            "source_timezone": "America/New_York",
+            "time": "16:30",
+            "target_timezone": "Asia/Tokyo"
+            }"#;
+        let partial = McpToolPartial::parse("mcp::time::convert_time", json_str)?;
+        let input = ToolInput::McpTool(McpToolInput { partial });
+
+        let tool = McpTool::new(
+            "time".to_string(),
+            "convert_time".to_string(),
+            "Convert time".to_string(),
+            CONVERT_TIME_SCHEMA.clone(),
+            Arc::clone(&client),
+        );
+
+        let result = tool.invoke(input).await?;
+
+        // Verify the response
+        match result {
+            ToolOutput::McpTool(response) => {
+                assert!(
+                    response.data.is_object(),
+                    "Response should be a JSON object"
+                );
+            }
+            _ => panic!("Unexpected response type"),
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_mcp_tool_errors() -> anyhow::Result<()> {
+        let client = setup_test_client().await?;
+
+        let dyn_tool = McpTool::new(
+            "time".to_string(),
+            "convert_time".to_string(),
+            "Convert time".to_string(),
+            CONVERT_TIME_SCHEMA.clone(),
+            Arc::clone(&client),
+        );
+
+        // Test wrong tool input type
+        let wrong_input = ToolInput::OpenFile(OpenFileRequest::new(
+            "test.txt".to_string(),
+            "http://localhost".to_string(),
+            None,
+            None,
+        ));
+        let result = dyn_tool.invoke(wrong_input).await;
+        assert!(matches!(result, Err(ToolError::WrongToolInput(_))));
+
+        // Test missing required field
+        let json_str = r#"{"source_timezone": "America/New_York"}"#;
+        let partial = McpToolPartial::parse("mcp::time::convert_time", json_str).unwrap();
+        let input = McpToolInput { partial };
+        let result = dyn_tool.invoke(ToolInput::McpTool(input)).await;
+        assert!(result.is_err(), "Should fail with missing required field");
+
+        // Test with invalid JSON
+        let invalid_json = r#"{"name": "Test Note", content: }"#; // Invalid JSON syntax
+        let partial = McpToolPartial::parse("mcp::notes_server::add_note", invalid_json);
+        assert!(partial.is_err(), "Should fail with invalid JSON");
+
+        // Test with all required fields
+        let valid_json = r#"{
+            "source_timezone": "America/New_York",
+            "time": "16:30",
+            "target_timezone": "Asia/Tokyo"
+        }"#;
+        let partial = McpToolPartial::parse("mcp::time::convert_time", valid_json).unwrap();
+        let input = McpToolInput { partial };
+        let result = dyn_tool.invoke(ToolInput::McpTool(input)).await;
+        assert!(result.is_ok(), "Should succeed with all required fields");
+
+        Ok(())
+    }
+}

--- a/sidecar/src/agentic/tool/mcp/mod.rs
+++ b/sidecar/src/agentic/tool/mcp/mod.rs
@@ -1,0 +1,3 @@
+pub mod init;
+pub mod input;
+pub mod integration_tool;

--- a/sidecar/src/agentic/tool/mod.rs
+++ b/sidecar/src/agentic/tool/mod.rs
@@ -31,6 +31,7 @@ pub mod input;
 pub mod jitter;
 pub mod kw_search;
 pub mod lsp;
+pub mod mcp;
 pub mod output;
 pub mod plan;
 pub mod ref_filter;

--- a/sidecar/src/agentic/tool/output.rs
+++ b/sidecar/src/agentic/tool/output.rs
@@ -1,6 +1,7 @@
 //! Contains the output of a tool which can be used by any of the callers
 
 use crate::agentic::symbol::ui_event::RelevantReference;
+use crate::agentic::tool::mcp::integration_tool::McpToolResponse;
 
 use super::{
     code_edit::{
@@ -234,6 +235,19 @@ pub enum ToolOutput {
     FindFiles(FindFilesResponse),
     // Request screenshot output
     RequestScreenshot(RequestScreenshotOutput),
+    // dynamically configured MCP servers
+    McpTool(McpToolResponse),
+}
+
+macro_rules! impl_output {
+    ($name:ident, $variant:ident, $type:ty) => {
+        pub fn $name(self) -> Option<$type> {
+            match self {
+                ToolOutput::$variant(response) => Some(response),
+                _ => None,
+            }
+        }
+    };
 }
 
 impl ToolOutput {
@@ -916,4 +930,6 @@ impl ToolOutput {
             _ => None,
         }
     }
+
+    impl_output!(get_mcp_response, McpTool, McpToolResponse);
 }

--- a/sidecar/src/agentic/tool/session/service.rs
+++ b/sidecar/src/agentic/tool/session/service.rs
@@ -1150,6 +1150,7 @@ impl SessionService {
                         ToolInputPartial::RequestScreenshot(_) => {
                             tool_type.to_string().bright_white().to_string()
                         }
+                        ToolInputPartial::McpTool(_) => tool_type.to_string().cyan().to_string(),
                     };
                     state_params.push(tool_str);
                 }

--- a/sidecar/src/agentic/tool/session/session.rs
+++ b/sidecar/src/agentic/tool/session/session.rs
@@ -2949,6 +2949,9 @@ reason: {}"#,
                     exchange_id.to_owned(),
                 );
             }
+            ToolInputPartial::McpTool(_) => {
+                todo!("MCP tool implementation is not yet complete");
+            }
         }
         Ok(self)
     }

--- a/sidecar/src/agentic/tool/type.rs
+++ b/sidecar/src/agentic/tool/type.rs
@@ -156,6 +156,8 @@ pub enum ToolType {
     FindFiles,
     // Request browser screenshot for web applications
     RequestScreenshot,
+    // dynamically configured MCP servers
+    McpTool(String),
 }
 
 impl std::fmt::Display for ToolType {
@@ -259,6 +261,7 @@ impl std::fmt::Display for ToolType {
             ToolType::SemanticSearch => write!(f, "semantic_search"),
             ToolType::FindFiles => write!(f, "find_file"),
             ToolType::RequestScreenshot => write!(f, "request_screenshot"),
+            ToolType::McpTool(name) => write!(f, "{}", name),
         }
     }
 }

--- a/sidecar/src/application/application.rs
+++ b/sidecar/src/application/application.rs
@@ -85,19 +85,22 @@ impl Application {
         let fill_in_middle_state = Arc::new(FillInMiddleState::new());
         let symbol_tracker = Arc::new(SymbolTrackerInline::new(editor_parsing.clone()));
 
-        let tool_broker = Arc::new(ToolBroker::new(
-            llm_broker.clone(),
-            Arc::new(CodeEditBroker::new()),
-            symbol_tracker.clone(),
-            language_parsing.clone(),
-            // do not apply the edits directly
-            ToolBrokerConfiguration::new(None, config.apply_directly),
-            LLMProperties::new(
-                LLMType::Gpt4O,
-                LLMProvider::OpenAI,
-                LLMProviderAPIKeys::OpenAI(OpenAIProvider::new("".to_owned())),
-            ),
-        ));
+        let tool_broker = Arc::new(
+            ToolBroker::new(
+                llm_broker.clone(),
+                Arc::new(CodeEditBroker::new()),
+                symbol_tracker.clone(),
+                language_parsing.clone(),
+                // do not apply the edits directly
+                ToolBrokerConfiguration::new(None, config.apply_directly),
+                LLMProperties::new(
+                    LLMType::Gpt4O,
+                    LLMProvider::OpenAI,
+                    LLMProviderAPIKeys::OpenAI(OpenAIProvider::new("".to_owned())),
+                ),
+            )
+            .await,
+        );
         let tool_box = Arc::new(ToolBox::new(
             tool_broker.clone(),
             symbol_tracker.clone(),

--- a/sidecar/src/bin/code_editing_flow.rs
+++ b/sidecar/src/bin/code_editing_flow.rs
@@ -54,25 +54,28 @@ async fn main() {
         LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned()));
     let editor_parsing = Arc::new(EditorParsing::default());
     let symbol_broker = Arc::new(SymbolTrackerInline::new(editor_parsing.clone()));
-    let tool_broker = Arc::new(ToolBroker::new(
-        Arc::new(LLMBroker::new().await.expect("to initialize properly")),
-        Arc::new(CodeEditBroker::new()),
-        symbol_broker.clone(),
-        Arc::new(TSLanguageParsing::init()),
-        // for our testing workflow we want to apply the edits directly
-        ToolBrokerConfiguration::new(None, true),
-        LLMProperties::new(
-            LLMType::Gpt4O,
-            LLMProvider::OpenAI,
-            LLMProviderAPIKeys::OpenAI(OpenAIProvider::new("".to_owned())),
-        ), // LLMProperties::new(
-           //     LLMType::GeminiPro,
-           //     LLMProvider::GoogleAIStudio,
-           //     LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new(
-           //         "".to_owned(),
-           //     )),
-           // ),
-    ));
+    let tool_broker = Arc::new(
+        ToolBroker::new(
+            Arc::new(LLMBroker::new().await.expect("to initialize properly")),
+            Arc::new(CodeEditBroker::new()),
+            symbol_broker.clone(),
+            Arc::new(TSLanguageParsing::init()),
+            // for our testing workflow we want to apply the edits directly
+            ToolBrokerConfiguration::new(None, true),
+            LLMProperties::new(
+                LLMType::Gpt4O,
+                LLMProvider::OpenAI,
+                LLMProviderAPIKeys::OpenAI(OpenAIProvider::new("".to_owned())),
+            ), // LLMProperties::new(
+               //     LLMType::GeminiPro,
+               //     LLMProvider::GoogleAIStudio,
+               //     LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new(
+               //         "".to_owned(),
+               //     )),
+               // ),
+        )
+        .await,
+    );
 
     // let file_path = "/Users/skcd/test_repo/sidecar/llm_client/src/provider.rs";
     // let _file_paths =

--- a/sidecar/src/bin/midwit_tool_use.rs
+++ b/sidecar/src/bin/midwit_tool_use.rs
@@ -75,18 +75,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let editor_parsing = Arc::new(EditorParsing::default());
     let symbol_broker = Arc::new(SymbolTrackerInline::new(editor_parsing.clone()));
     let llm_broker = Arc::new(LLMBroker::new().await.expect("to initialize properly"));
-    let tool_broker = Arc::new(ToolBroker::new(
-        llm_broker.clone(),
-        Arc::new(CodeEditBroker::new()),
-        symbol_broker.clone(),
-        Arc::new(TSLanguageParsing::init()),
-        ToolBrokerConfiguration::new(None, true),
-        LLMProperties::new(
-            LLMType::GeminiPro,
-            LLMProvider::GoogleAIStudio,
-            LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned())),
-        ),
-    ));
+    let tool_broker = Arc::new(
+        ToolBroker::new(
+            llm_broker.clone(),
+            Arc::new(CodeEditBroker::new()),
+            symbol_broker.clone(),
+            Arc::new(TSLanguageParsing::init()),
+            ToolBrokerConfiguration::new(None, true),
+            LLMProperties::new(
+                LLMType::GeminiPro,
+                LLMProvider::GoogleAIStudio,
+                LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned())),
+            ),
+        )
+        .await,
+    );
 
     let tool_box = Arc::new(ToolBox::new(tool_broker, symbol_broker, editor_parsing));
 

--- a/sidecar/src/bin/print_mcts_tree.rs
+++ b/sidecar/src/bin/print_mcts_tree.rs
@@ -30,18 +30,21 @@ async fn main() {
     let editor_parsing = Arc::new(EditorParsing::default());
     let symbol_broker = Arc::new(SymbolTrackerInline::new(editor_parsing.clone()));
     let llm_broker = Arc::new(LLMBroker::new().await.expect("to initialize properly"));
-    let tool_broker = Arc::new(ToolBroker::new(
-        llm_broker.clone(),
-        Arc::new(CodeEditBroker::new()),
-        symbol_broker.clone(),
-        Arc::new(TSLanguageParsing::init()),
-        ToolBrokerConfiguration::new(None, true),
-        LLMProperties::new(
-            LLMType::GeminiPro,
-            LLMProvider::GoogleAIStudio,
-            LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned())),
-        ),
-    ));
+    let tool_broker = Arc::new(
+        ToolBroker::new(
+            llm_broker.clone(),
+            Arc::new(CodeEditBroker::new()),
+            symbol_broker.clone(),
+            Arc::new(TSLanguageParsing::init()),
+            ToolBrokerConfiguration::new(None, true),
+            LLMProperties::new(
+                LLMType::GeminiPro,
+                LLMProvider::GoogleAIStudio,
+                LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned())),
+            ),
+        )
+        .await,
+    );
 
     let tool_box = Arc::new(ToolBox::new(tool_broker, symbol_broker, editor_parsing));
 

--- a/sidecar/src/bin/swe_bench_mcts.rs
+++ b/sidecar/src/bin/swe_bench_mcts.rs
@@ -114,18 +114,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let editor_parsing = Arc::new(EditorParsing::default());
     let symbol_broker = Arc::new(SymbolTrackerInline::new(editor_parsing.clone()));
     let llm_broker = Arc::new(LLMBroker::new().await.expect("to initialize properly"));
-    let tool_broker = Arc::new(ToolBroker::new(
-        llm_broker.clone(),
-        Arc::new(CodeEditBroker::new()),
-        symbol_broker.clone(),
-        Arc::new(TSLanguageParsing::init()),
-        ToolBrokerConfiguration::new(None, true),
-        LLMProperties::new(
-            LLMType::GeminiPro,
-            LLMProvider::GoogleAIStudio,
-            LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned())),
-        ),
-    ));
+    let tool_broker = Arc::new(
+        ToolBroker::new(
+            llm_broker.clone(),
+            Arc::new(CodeEditBroker::new()),
+            symbol_broker.clone(),
+            Arc::new(TSLanguageParsing::init()),
+            ToolBrokerConfiguration::new(None, true),
+            LLMProperties::new(
+                LLMType::GeminiPro,
+                LLMProvider::GoogleAIStudio,
+                LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned())),
+            ),
+        )
+        .await,
+    );
 
     let tool_box = Arc::new(ToolBox::new(tool_broker, symbol_broker, editor_parsing));
 

--- a/sidecar/src/bin/swe_bench_submission.rs
+++ b/sidecar/src/bin/swe_bench_submission.rs
@@ -50,18 +50,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let editor_parsing = Arc::new(EditorParsing::default());
     let symbol_broker = Arc::new(SymbolTrackerInline::new(editor_parsing.clone()));
     let llm_broker = Arc::new(LLMBroker::new().await.expect("to initialize properly"));
-    let tool_broker = Arc::new(ToolBroker::new(
-        llm_broker.clone(),
-        Arc::new(CodeEditBroker::new()),
-        symbol_broker.clone(),
-        Arc::new(TSLanguageParsing::init()),
-        ToolBrokerConfiguration::new(None, true),
-        LLMProperties::new(
-            LLMType::GeminiPro,
-            LLMProvider::GoogleAIStudio,
-            LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned())),
-        ),
-    ));
+    let tool_broker = Arc::new(
+        ToolBroker::new(
+            llm_broker.clone(),
+            Arc::new(CodeEditBroker::new()),
+            symbol_broker.clone(),
+            Arc::new(TSLanguageParsing::init()),
+            ToolBrokerConfiguration::new(None, true),
+            LLMProperties::new(
+                LLMType::GeminiPro,
+                LLMProvider::GoogleAIStudio,
+                LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned())),
+            ),
+        )
+        .await,
+    );
 
     let tool_box = Arc::new(ToolBox::new(tool_broker, symbol_broker, editor_parsing));
 

--- a/sidecar/src/bin/terminal.rs
+++ b/sidecar/src/bin/terminal.rs
@@ -50,25 +50,28 @@ async fn main() {
     let symbol_broker = Arc::new(SymbolTrackerInline::new(editor_parsing.clone()));
     let llm_broker = LLMBroker::new().await.expect("to initialize properly");
 
-    let tool_broker = Arc::new(ToolBroker::new(
-        Arc::new(llm_broker),
-        Arc::new(CodeEditBroker::new()),
-        symbol_broker.clone(),
-        Arc::new(TSLanguageParsing::init()),
-        // for our testing workflow we want to apply the edits directly
-        ToolBrokerConfiguration::new(None, true),
-        LLMProperties::new(
-            LLMType::Gpt4O,
-            LLMProvider::OpenAI,
-            LLMProviderAPIKeys::OpenAI(OpenAIProvider::new("".to_owned())),
-        ), // LLMProperties::new(
-           //     LLMType::GeminiPro,
-           //     LLMProvider::GoogleAIStudio,
-           //     LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new(
-           //         "".to_owned(),
-           //     )),
-           // ),
-    ));
+    let tool_broker = Arc::new(
+        ToolBroker::new(
+            Arc::new(llm_broker),
+            Arc::new(CodeEditBroker::new()),
+            symbol_broker.clone(),
+            Arc::new(TSLanguageParsing::init()),
+            // for our testing workflow we want to apply the edits directly
+            ToolBrokerConfiguration::new(None, true),
+            LLMProperties::new(
+                LLMType::Gpt4O,
+                LLMProvider::OpenAI,
+                LLMProviderAPIKeys::OpenAI(OpenAIProvider::new("".to_owned())),
+            ), // LLMProperties::new(
+               //     LLMType::GeminiPro,
+               //     LLMProvider::GoogleAIStudio,
+               //     LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new(
+               //         "".to_owned(),
+               //     )),
+               // ),
+        )
+        .await,
+    );
 
     let _user_context = UserContext::new(vec![], vec![], None, vec![]);
 

--- a/sidecar/src/bin/tool_box_git_diff.rs
+++ b/sidecar/src/bin/tool_box_git_diff.rs
@@ -23,18 +23,21 @@ async fn main() {
     // interested in
     let editor_parsing = Arc::new(EditorParsing::default());
     let symbol_broker = Arc::new(SymbolTrackerInline::new(editor_parsing.clone()));
-    let tool_broker = Arc::new(ToolBroker::new(
-        Arc::new(LLMBroker::new().await.expect("to initialize properly")),
-        Arc::new(CodeEditBroker::new()),
-        symbol_broker.clone(),
-        Arc::new(TSLanguageParsing::init()),
-        ToolBrokerConfiguration::new(None, true),
-        LLMProperties::new(
-            LLMType::GeminiPro,
-            LLMProvider::GoogleAIStudio,
-            LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned())),
-        ),
-    ));
+    let tool_broker = Arc::new(
+        ToolBroker::new(
+            Arc::new(LLMBroker::new().await.expect("to initialize properly")),
+            Arc::new(CodeEditBroker::new()),
+            symbol_broker.clone(),
+            Arc::new(TSLanguageParsing::init()),
+            ToolBrokerConfiguration::new(None, true),
+            LLMProperties::new(
+                LLMType::GeminiPro,
+                LLMProvider::GoogleAIStudio,
+                LLMProviderAPIKeys::GoogleAIStudio(GoogleAIStudioKey::new("".to_owned())),
+            ),
+        )
+        .await,
+    );
 
     let tool_box = Arc::new(ToolBox::new(tool_broker, symbol_broker, editor_parsing));
 

--- a/sidecar/src/mcts/action_node.rs
+++ b/sidecar/src/mcts/action_node.rs
@@ -1977,6 +1977,7 @@ impl SearchTree {
                         ToolInputPartial::RequestScreenshot(_) => {
                             tool_type.to_string().bright_white().to_string()
                         }
+                        ToolInputPartial::McpTool(_) => tool_type.to_string().cyan().to_string(),
                     };
                     state_params.push(tool_str);
                 }

--- a/sidecar/src/mcts/execution/inference.rs
+++ b/sidecar/src/mcts/execution/inference.rs
@@ -575,6 +575,9 @@ Always include the <thinking></thinking> section before using the tool."#
             ToolInputPartial::CodeEditing(_) => {
                 todo!("code editing is not supported with the inference engine for code editing, use anthropic computer use api instead")
             }
+            ToolInputPartial::McpTool(_) => {
+                todo!("MCP tools are not supported with the inference engine")
+            }
             ToolInputPartial::LSPDiagnostics(_) => {
                 todo!("LSP diagnostics are not supported right now")
             }
@@ -741,7 +744,7 @@ Terminal output: {}"#,
                 let message = format!(
                     r#"Here's the result of running the tests on the following files:
 {}
-                
+
 Test Output from the script (we also have to setup the test runner):
 Exit code: {}
 Output:


### PR DESCRIPTION
There is an existing PR to introduce the foundations for MCP integration: https://github.com/codestoryai/sidecar/pull/1635

However, it's a month old now and probably the author is now busy with other things.

This PR is based on the other one, though with several implementation changes.

The main things different to the previous PR are:

* rather than trying to map between pseudo-XML from the LLM and the JSON needed for MCP tool calls, I am trying the strategy of just asking the LLM for a JSON object (embedded inside the outer tool usage XML tags).

This is similar to how Cline works, and I've also done some experimentation with this format in sidecar (though not included those changes in this PR because it would lead to a giant PR, and they're not finished anyway).

Therefore the "partial" input struct now contains a serde_json::Map (i.e. a JSON object), instead of a HashMap of string->string, and I've updated the tool_description and tool_input_format methods to match this alternate approach.

* rather than adding an async `with_mcp` method to be called on the tool broker after initialization, I've made the tool broker `new` method async, and tools are discovered inside the new method. Also, whilst the previous PR would bubble up errors from MCP initialization (and therefore potentially cause the sidecar to fail to start), I've made the broker new() method log any error returned by the mcp tool discovery function, and then continue with normal program execution

* rather than raising an error if multiple MCP servers have a tool with the same name, I've changed the code to give the MCP tools a combined, normalized name that will be unique across servers, e.g. server "notes-Server" with tool "add-note" becomes a tool named "mcp::notes_server::add_note"

* added separate partial input/input structs, rather than just a partial input class, as this will be required to integrate it into the agent code. I think it would make life easier if application context were passed around as a separate parameter to remove the need for the partial structs pattern altogether, but that is a refactoring beyond the scope of this PR

* I've renamed things from DynamicMCPTool/Input/etc to McpTool/Input, etc. If people object to this renaming I can change it back again...

* changed the integration tests to use an MCP time server rather than a simple notes server, because I couldn't easily find the docs for the notes server, plus it only worked with Python 3.12
