### PR TITLE
MCP in tool use agent

### DIFF
--- a/sidecar/src/agentic/symbol/errors.rs
+++ b/sidecar/src/agentic/symbol/errors.rs
@@ -1,4 +1,5 @@
 use llm_client::clients::types::LLMClientError;
+use serde_json;
 use thiserror::Error;
 use tokio::sync::{mpsc::error::SendError, oneshot::error::RecvError};
 
@@ -91,4 +92,7 @@ pub enum SymbolError {
 
     #[error("Test case is passing")]
     TestCaseIsPassing,
+
+    #[error("Invalid JSON: {0}")]
+    InvalidJson(serde_json::Error),
 }

--- a/sidecar/src/agentic/tool/session/service.rs
+++ b/sidecar/src/agentic/tool/session/service.rs
@@ -423,6 +423,7 @@ impl SessionService {
                     // ToolType::SemanticSearch,
                 ]
                 .into_iter()
+                .chain(tool_box.mcp_tools().iter().cloned())
                 .chain(if is_devtools_context {
                     vec![ToolType::RequestScreenshot]
                 } else {


### PR DESCRIPTION
This PR is a follow-up to the previous one, and adds the logic for the agent to actually use the created MCP tool instances.

![image](https://github.com/user-attachments/assets/64a964c2-eb18-4dc2-9a85-c5f39f105090)

Note that tool responses from an MCP server can be one of:
a) text (which is often implemented as a JSON object, but can also be a plain text string)
b) an image available at a uri
c)  an embedded resource, this includes both the uri of the resource and the text or binary blob data of its contents

The code handles these cases as follow:
a) text: output text to the LLM (this includes JSON responses, which are normally pretty printed by the standard server SDKs)

b) image: output "format!("image at {}", uri)," to the LLM

c) embedded resource: for text resources output the text contents, for binary resources ouput ""unsupported MCP blob embedded resource""

For reference:

Schema is here:
https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json#L80

Docs are here. They docs don't really cover embedded resources in any detail, I'm not sure to what extent any MCP servers actually use them or whether it's just an idea someone had for the protocol:
https://modelcontextprotocol.io/docs/concepts/architecture