### PR TITLE
[agent_farm] add support for overwrite_file endpoint (Run ID: codestoryai_sidecar_issue_1970_eda56e19)

### DIFF
--- a/sidecar/src/agentic/tool/file/models/mod.rs
+++ b/sidecar/src/agentic/tool/file/models/mod.rs
@@ -1,1 +1,2 @@
 pub mod anthropic;
+pub mod overwrite;

--- a/sidecar/src/agentic/tool/file/models/overwrite.rs
+++ b/sidecar/src/agentic/tool/file/models/overwrite.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use serde_xml_rs::from_str;
+use reqwest::Client;
+
+use crate::agentic::tool::file::types::FileImportantError;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename = "overwrite")]
+pub struct OverwriteFileXMLRequest {
+    fs_file_path: String,
+    updated_content: String,
+}
+
+impl OverwriteFileXMLRequest {
+    pub fn parse_response(response: &str) -> Result<Self, FileImportantError> {
+        if response.is_empty() {
+            return Err(FileImportantError::EmptyResponse);
+        }
+
+        let lines = response
+            .lines()
+            .skip_while(|line| !line.contains("<reply>"))
+            .skip(1)
+            .take_while(|line| !line.contains("</reply>"))
+            .map(|line| line.to_owned())
+            .collect::<Vec<String>>();
+
+        let line_string = lines.join("\n");
+
+        match from_str::<OverwriteFileXMLRequest>(&line_string) {
+            Ok(parsed) => Ok(parsed),
+            Err(e) => {
+                eprintln!("parsing error: {:?}", e);
+                Err(FileImportantError::SerdeError(crate::agentic::tool::file::types::SerdeError::new(
+                    e,
+                    line_string.to_owned(),
+                )))
+            }
+        }
+    }
+}
+
+pub struct OverwriteFile {
+    client: Arc<Client>,
+    base_url: String,
+}
+
+impl OverwriteFile {
+    pub fn new(client: Arc<Client>, base_url: String) -> Self {
+        Self { client, base_url }
+    }
+
+    pub async fn overwrite_file(&self, fs_file_path: String, updated_content: String) -> Result<(), anyhow::Error> {
+        let url = format!("{}/api/file/overwrite_file", self.base_url);
+        
+        let response = self.client
+            .post(&url)
+            .json(&serde_json::json!({
+                "file_path": fs_file_path,
+                "updated_content": updated_content,
+            }))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "Failed to overwrite file: {}",
+                response.status()
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/sidecar/src/bin/webserver.rs
+++ b/sidecar/src/bin/webserver.rs
@@ -277,5 +277,7 @@ fn tree_sitter_router() -> Router {
 
 fn file_operations_router() -> Router {
     use axum::routing::*;
-    Router::new().route("/edit_file", post(sidecar::webserver::file_edit::file_edit))
+    Router::new()
+        .route("/edit_file", post(sidecar::webserver::file_edit::file_edit))
+        .route("/overwrite_file", post(sidecar::webserver::file_edit::overwrite_file))
 }

--- a/sidecar/src/webserver/file_edit.rs
+++ b/sidecar/src/webserver/file_edit.rs
@@ -19,6 +19,41 @@ use super::model_selection::LLMClientConfig;
 use super::types::{ApiResponse, Result};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct OverwriteFileRequest {
+    pub file_path: String,
+    pub updated_content: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct OverwriteFileResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+impl ApiResponse for OverwriteFileResponse {}
+
+pub async fn overwrite_file(
+    Extension(_app): Extension<Application>,
+    Json(request): Json<OverwriteFileRequest>,
+) -> Result<impl IntoResponse> {
+    info!(
+        event_name = "overwrite_file",
+        file_path = request.file_path.as_str()
+    );
+
+    // Write the updated content to the file
+    tokio::fs::write(&request.file_path, &request.updated_content)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to write file: {}", e))?;
+
+    Ok(Json(OverwriteFileResponse {
+        success: true,
+        message: format!("Successfully overwrote file {}", request.file_path),
+    }))
+}
+
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EditFileRequest {
     pub file_path: String,
     pub file_content: String,


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_1970_eda56e19 Tries to fix: #1970

Implements: Added **OverwriteFile** tool and `/api/file/overwrite_file` endpoint for file content updates.

- **Added:** New `OverwriteFileRequest`/`Response` types and endpoint handler in `file_edit.rs`
- **Created:** OverwriteFile tool implementation with XML parsing support.
- **Updated:** File operations router to include the new endpoint.

Ready for review! 🚀