### PR TITLE
[agent_farm] 429 from codestory provider (Run ID: codestoryai_sidecar_issue_1974_7c40be01)

### DIFF
--- a/llm_client/src/clients/codestory.rs
+++ b/llm_client/src/clients/codestory.rs
@@ -254,10 +254,31 @@ impl CodeStoryClient {
             .send()
             .await?;
 
-        // Check for 401 Unauthorized status
-        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
-            error!("Unauthorized access to Codestory API");
-            return Err(LLMClientError::UnauthorizedAccess);
+        match response.status() {
+            reqwest::StatusCode::UNAUTHORIZED => {
+                error!("Unauthorized access to Codestory API");
+                return Err(LLMClientError::UnauthorizedAccess);
+            }
+            reqwest::StatusCode::TOO_MANY_REQUESTS => {
+                error!("Rate limit exceeded for Codestory API");
+                return Err(LLMClientError::RateLimitExceeded);
+            }
+            _ => {}
+        }
+
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            error!("Rate limit exceeded for Codestory API");
+            return Err(LLMClientError::RateLimitExceeded);
+        }
+
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            error!("Rate limit exceeded for Codestory API");
+            return Err(LLMClientError::RateLimitExceeded);
+        }
+
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            error!("Rate limit exceeded for Codestory API");
+            return Err(LLMClientError::RateLimitExceeded);
         }
 
         let mut response_stream = response.bytes_stream().eventsource();
@@ -380,10 +401,16 @@ impl LLMClient for CodeStoryClient {
             .send()
             .await?;
 
-        // Check for 401 Unauthorized status
-        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
-            error!("Unauthorized access to Codestory API");
-            return Err(LLMClientError::UnauthorizedAccess);
+        match response.status() {
+            reqwest::StatusCode::UNAUTHORIZED => {
+                error!("Unauthorized access to Codestory API");
+                return Err(LLMClientError::UnauthorizedAccess);
+            }
+            reqwest::StatusCode::TOO_MANY_REQUESTS => {
+                error!("Rate limit exceeded for Codestory API");
+                return Err(LLMClientError::RateLimitExceeded);
+            }
+            _ => {}
         }
 
         let mut response_stream = response.bytes_stream().eventsource();
@@ -440,10 +467,16 @@ impl LLMClient for CodeStoryClient {
             .send()
             .await?;
 
-        // Check for 401 Unauthorized status
-        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
-            error!("Unauthorized access to Codestory API");
-            return Err(LLMClientError::UnauthorizedAccess);
+        match response.status() {
+            reqwest::StatusCode::UNAUTHORIZED => {
+                error!("Unauthorized access to Codestory API");
+                return Err(LLMClientError::UnauthorizedAccess);
+            }
+            reqwest::StatusCode::TOO_MANY_REQUESTS => {
+                error!("Rate limit exceeded for Codestory API");
+                return Err(LLMClientError::RateLimitExceeded);
+            }
+            _ => {}
         }
 
         let mut response_stream = response.bytes_stream().eventsource();

--- a/llm_client/src/clients/types.rs
+++ b/llm_client/src/clients/types.rs
@@ -998,6 +998,9 @@ pub enum LLMClientError {
 
     #[error("Unauthorized access to API")]
     UnauthorizedAccess,
+
+    #[error("Rate limit exceeded")]
+    RateLimitExceeded,
 }
 
 #[async_trait]

--- a/sidecar/src/webserver/agent_stream.rs
+++ b/sidecar/src/webserver/agent_stream.rs
@@ -62,7 +62,7 @@ pub async fn generate_agent_stream(
                             // Check if error is an LLMClientError::UnauthorizedAccess
                             if let Some(llm_err) = e.source() {
                                 if let Some(llm_client_err) = llm_err.downcast_ref::<LLMClientError>() {
-                                    if matches!(llm_client_err, LLMClientError::UnauthorizedAccess) {
+                                    if matches!(llm_client_err, LLMClientError::UnauthorizedAccess | LLMClientError::RateLimitExceeded) {
                                         break 'outer Err(e);
                                     }
                                 }

--- a/sidecar/src/webserver/agentic.rs
+++ b/sidecar/src/webserver/agentic.rs
@@ -1083,13 +1083,13 @@ pub async fn agent_session_chat(
                         SymbolError::LLMClientError(LLMClientError::UnauthorizedAccess)
                         | SymbolError::ToolError(ToolError::LLMClientError(
                             LLMClientError::UnauthorizedAccess,
-                        )) => "Unauthorized access. Please check your API key and try again.",
+                        )) => "Unauthorized access. Please check your API key and try again.".to_string(),
                         SymbolError::LLMClientError(LLMClientError::RateLimitExceeded)
                         | SymbolError::ToolError(ToolError::LLMClientError(
                             LLMClientError::RateLimitExceeded,
-                        )) => "Rate limit exceeded. Please try again later.",
-                        _ => &format!("Internal server error: {}", e),
-                    }.to_string();
+                        )) => "Rate limit exceeded. Please try again later.".to_string(),
+                        _ => format!("Internal server error: {}", e),
+                    };
                     let _ = sender.send(UIEventWithID::error(session_id.clone(), error_msg));
                 }
                 Err(e) => {
@@ -1799,13 +1799,13 @@ pub async fn agent_session_plan_iterate(
                         SymbolError::LLMClientError(LLMClientError::UnauthorizedAccess)
                         | SymbolError::ToolError(ToolError::LLMClientError(
                             LLMClientError::UnauthorizedAccess,
-                        )) => "Unauthorized access. Please check your API key and try again.",
+                        )) => "Unauthorized access. Please check your API key and try again.".to_string(),
                         SymbolError::LLMClientError(LLMClientError::RateLimitExceeded)
                         | SymbolError::ToolError(ToolError::LLMClientError(
                             LLMClientError::RateLimitExceeded,
-                        )) => "Rate limit exceeded. Please try again later.",
-                        _ => &format!("Internal server error: {}", e),
-                    }.to_string();
+                        )) => "Rate limit exceeded. Please try again later.".to_string(),
+                        _ => format!("Internal server error: {}", e),
+                    };
                     let _ = sender.send(UIEventWithID::error(session_id.clone(), error_msg));
                 }
                 Err(e) => {
@@ -1957,13 +1957,13 @@ pub async fn agent_session_plan(
                         SymbolError::LLMClientError(LLMClientError::UnauthorizedAccess)
                         | SymbolError::ToolError(ToolError::LLMClientError(
                             LLMClientError::UnauthorizedAccess,
-                        )) => "Unauthorized access. Please check your API key and try again.",
+                        )) => "Unauthorized access. Please check your API key and try again.".to_string(),
                         SymbolError::LLMClientError(LLMClientError::RateLimitExceeded)
                         | SymbolError::ToolError(ToolError::LLMClientError(
                             LLMClientError::RateLimitExceeded,
-                        )) => "Rate limit exceeded. Please try again later.",
-                        _ => &format!("Internal server error: {}", e),
-                    }.to_string();
+                        )) => "Rate limit exceeded. Please try again later.".to_string(),
+                        _ => format!("Internal server error: {}", e),
+                    };
                     let _ = sender.send(UIEventWithID::error(session_id.clone(), error_msg));
                 }
                 Err(e) => {

--- a/sidecar/src/webserver/agentic.rs
+++ b/sidecar/src/webserver/agentic.rs
@@ -1083,10 +1083,13 @@ pub async fn agent_session_chat(
                         SymbolError::LLMClientError(LLMClientError::UnauthorizedAccess)
                         | SymbolError::ToolError(ToolError::LLMClientError(
                             LLMClientError::UnauthorizedAccess,
-                        )) => "Unauthorized access. Please check your API key and try again."
-                            .to_string(),
-                        _ => format!("Internal server error: {}", e),
-                    };
+                        )) => "Unauthorized access. Please check your API key and try again.",
+                        SymbolError::LLMClientError(LLMClientError::RateLimitExceeded)
+                        | SymbolError::ToolError(ToolError::LLMClientError(
+                            LLMClientError::RateLimitExceeded,
+                        )) => "Rate limit exceeded. Please try again later.",
+                        _ => &format!("Internal server error: {}", e),
+                    }.to_string();
                     let _ = sender.send(UIEventWithID::error(session_id.clone(), error_msg));
                 }
                 Err(e) => {
@@ -1791,15 +1794,18 @@ pub async fn agent_session_plan_iterate(
             match result {
                 Ok(Ok(_)) => (),
                 Ok(Err(e)) => {
-                    error!("Error in agent_tool_use: {:?}", e);
+                    error!("Error in agent_session_plan_iterate: {:?}", e);
                     let error_msg = match e {
                         SymbolError::LLMClientError(LLMClientError::UnauthorizedAccess)
                         | SymbolError::ToolError(ToolError::LLMClientError(
                             LLMClientError::UnauthorizedAccess,
-                        )) => "Unauthorized access. Please check your API key and try again."
-                            .to_string(),
-                        _ => format!("Internal server error: {}", e),
-                    };
+                        )) => "Unauthorized access. Please check your API key and try again.",
+                        SymbolError::LLMClientError(LLMClientError::RateLimitExceeded)
+                        | SymbolError::ToolError(ToolError::LLMClientError(
+                            LLMClientError::RateLimitExceeded,
+                        )) => "Rate limit exceeded. Please try again later.",
+                        _ => &format!("Internal server error: {}", e),
+                    }.to_string();
                     let _ = sender.send(UIEventWithID::error(session_id.clone(), error_msg));
                 }
                 Err(e) => {
@@ -1951,10 +1957,13 @@ pub async fn agent_session_plan(
                         SymbolError::LLMClientError(LLMClientError::UnauthorizedAccess)
                         | SymbolError::ToolError(ToolError::LLMClientError(
                             LLMClientError::UnauthorizedAccess,
-                        )) => "Unauthorized access. Please check your API key and try again."
-                            .to_string(),
-                        _ => format!("Internal server error: {}", e),
-                    };
+                        )) => "Unauthorized access. Please check your API key and try again.",
+                        SymbolError::LLMClientError(LLMClientError::RateLimitExceeded)
+                        | SymbolError::ToolError(ToolError::LLMClientError(
+                            LLMClientError::RateLimitExceeded,
+                        )) => "Rate limit exceeded. Please try again later.",
+                        _ => &format!("Internal server error: {}", e),
+                    }.to_string();
                     let _ = sender.send(UIEventWithID::error(session_id.clone(), error_msg));
                 }
                 Err(e) => {

--- a/sidecar/src/webserver/in_line_agent_stream.rs
+++ b/sidecar/src/webserver/in_line_agent_stream.rs
@@ -47,10 +47,10 @@ pub async fn generate_in_line_agent_stream(
                     Ok(Either::Right(Either::Left(next_action))) => match next_action {
                         Ok(n) => break next = n,
                         Err(e) => {
-                            // Check if error is an LLMClientError::UnauthorizedAccess
+                            // Check if error is an LLMClientError::UnauthorizedAccess or RateLimitExceeded
                             if let Some(llm_err) = e.source() {
                                 if let Some(llm_client_err) = llm_err.downcast_ref::<LLMClientError>() {
-                                    if matches!(llm_client_err, LLMClientError::UnauthorizedAccess) {
+                                    if matches!(llm_client_err, LLMClientError::UnauthorizedAccess | LLMClientError::RateLimitExceeded) {
                                         break 'outer Err(e);
                                     }
                                 }


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_1974_7c40be01 Tries to fix: #1974

**Feat:** Added rate limit error handling (429) for Codestory API provider.

- **Updated:** Added `RateLimitExceeded` variant to `LLMClientError` enum
- **Enhanced:** Status code handling in `stream_completion`, `stream_completion_with_tool`, and `stream_prompt_completion` methods to properly handle and bubble up 429 errors
- **Verified:** Changes with `cargo check` 🦀

Team, please review these error handling improvements for the Codestory provider. 🔍