### PR TITLE
[agent_farm] Whenever we run terminal commands make sure to limit it to 3k lines at the most (Run ID: codestoryai_sidecar_issue_1976_99754070)

### DIFF
--- a/sidecar/src/agentic/tool/terminal/terminal.rs
+++ b/sidecar/src/agentic/tool/terminal/terminal.rs
@@ -106,6 +106,18 @@ pub struct TerminalOutput {
 }
 
 impl TerminalOutput {
+    pub fn new(output: String) -> Self {
+        // Limit output to 3000 lines
+        let limited_output = output
+            .lines()
+            .take(3000)
+            .collect::<Vec<_>>()
+            .join("\n");
+        Self {
+            output: limited_output,
+        }
+    }
+
     pub fn output(&self) -> &str {
         &self.output
     }
@@ -138,7 +150,8 @@ impl Tool for TerminalTool {
             .await
             .map_err(|_e| ToolError::SerdeConversionFailed)?;
 
-        Ok(ToolOutput::TerminalCommand(terminal_response))
+        // Apply line limiting after JSON deserialization
+        Ok(ToolOutput::TerminalCommand(TerminalOutput::new(terminal_response.output)))
     }
 
     // credit Cline.


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_1976_99754070 Tries to fix: #1976

**Enhancement:** Implemented line limiting for terminal command output to prevent overwhelming output by capping at 3000 lines.

- **Added:** `TerminalOutput::new()` method that efficiently processes and limits command output
- **Updated:** Terminal command handling to use the new line limiting functionality

Please review these changes to ensure they align with our output management goals. 🔍