### PR TITLE
[agent_farm] delete the `delete_exchange_until` endpoint and any code associated with it (Run ID: codestoryai_sidecar_issue_1990_d03e2c53)

### DIFF
--- a/sidecar/src/bin/webserver.rs
+++ b/sidecar/src/bin/webserver.rs
@@ -251,12 +251,7 @@ fn agentic_router() -> Router {
         .route(
             "/user_handle_session_undo",
             post(sidecar::webserver::agentic::handle_session_undo),
-        )
-        .route(
-            "/delete_exchange_until",
-            post(sidecar::webserver::agentic::delete_exchanges_until),
-        )
-}
+        )}
 
 fn tree_sitter_router() -> Router {
     use axum::routing::*;

--- a/sidecar/src/webserver/agentic.rs
+++ b/sidecar/src/webserver/agentic.rs
@@ -1474,42 +1474,6 @@ pub struct AgenticVerifyModelConfigResponse {
 
 impl ApiResponse for AgenticVerifyModelConfigResponse {}
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct AgenticDeleteExchangesUntil {
-    session_id: String,
-    exchange_id: String,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct AgenticDeleteExchangesUntilResponse {
-    done: bool,
-}
-
-impl ApiResponse for AgenticDeleteExchangesUntilResponse {}
-
-pub async fn delete_exchanges_until(
-    Extension(app): Extension<Application>,
-    Json(AgenticDeleteExchangesUntil {
-        session_id,
-        exchange_id,
-    }): Json<AgenticDeleteExchangesUntil>,
-) -> Result<impl IntoResponse> {
-    println!("webserver::agent_session::delete_exchanges_until::hit");
-    println!(
-        "webserver::agent_session::delete_exchanges_until::session_id({})",
-        &session_id
-    );
-
-    let session_storage_path =
-        check_session_storage_path(app.config.clone(), session_id.to_string()).await;
-
-    let session_service = app.session_service.clone();
-    let _ = session_service
-        .delete_exchanges_until(&exchange_id, session_storage_path)
-        .await;
-    Ok(Json(AgenticDeleteExchangesUntilResponse { done: true }))
-}
-
 pub async fn verify_model_config(
     Extension(_app): Extension<Application>,
     Json(AgenticVerifyModelConfig {


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_1990_d03e2c53 Tries to fix: #1990

Cleanup: Removed deprecated `/delete_exchange_until` endpoint and associated code.

- **Removed:** Endpoint route from `webserver.rs`
- **Deleted:** `AgenticDeleteExchangesUntil` struct and implementation from `agentic.rs`
- ✅ `cargo check` passes with no errors

Please review these cleanup changes for any potential side effects on existing API consumers.