### PR TITLE
[agent_farm] update the sidecar version (Run ID: codestoryai_sidecar_issue_1992_2fcb0c0e)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "sidecar"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidecar"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_1992_2fcb0c0e Tries to fix: #1992

Update: Incremented sidecar version from `0.1.29` to `0.1.30`

- **Modified:** `sidecar/Cargo.toml` version number
- **Ready** for team review and deployment 🚀