### PR TITLE
[agent_farm] when doing fallback can you make sure we use google/gemini-2.0-flash-001 instead (Run ID: codestoryai_sidecar_issue_1998_f3b96484)

### DIFF
--- a/llm_client/src/clients/gemini_pro.rs
+++ b/llm_client/src/clients/gemini_pro.rs
@@ -36,8 +36,8 @@ impl GeminiProClient {
 
     fn model(&self, model: &LLMType) -> Option<String> {
         match model {
-            LLMType::GeminiPro => Some("gemini-2.0-flash-001".to_owned()),
-            LLMType::GeminiProFlash => Some("gemini-2.0-flash-001".to_owned()),
+            LLMType::GeminiPro => Some("gemini-1.5-pro-001".to_owned()),
+            LLMType::GeminiProFlash => Some("gemini-1.5-flash-001".to_owned()),
             _ => None,
         }
     }

--- a/llm_client/src/clients/gemini_pro.rs
+++ b/llm_client/src/clients/gemini_pro.rs
@@ -36,8 +36,8 @@ impl GeminiProClient {
 
     fn model(&self, model: &LLMType) -> Option<String> {
         match model {
-            LLMType::GeminiPro => Some("gemini-1.5-pro-001".to_owned()),
-            LLMType::GeminiProFlash => Some("gemini-1.5-flash-001".to_owned()),
+            LLMType::GeminiPro => Some("gemini-2.0-flash-001".to_owned()),
+            LLMType::GeminiProFlash => Some("gemini-2.0-flash-001".to_owned()),
             _ => None,
         }
     }

--- a/llm_client/src/clients/google_ai.rs
+++ b/llm_client/src/clients/google_ai.rs
@@ -38,9 +38,9 @@ impl GoogleAIStdioClient {
 
     fn model(&self, model: &LLMType) -> Option<String> {
         match model {
-            LLMType::GeminiPro => Some("gemini-2.0-flash-001".to_owned()),
-            LLMType::GeminiProFlash => Some("gemini-2.0-flash-001".to_owned()),
-            LLMType::Gemini2_0Flash => Some("gemini-2.0-flash-001".to_owned()),
+            LLMType::GeminiPro => Some("gemini-1.5-pro".to_owned()),
+            LLMType::GeminiProFlash => Some("gemini-1.5-flash".to_owned()),
+            LLMType::Gemini2_0Flash => Some("gemini-2.0-flash".to_owned()),
             LLMType::Gemini2_0FlashExperimental => Some("gemini-2.0-flash-exp".to_owned()),
             LLMType::Gemini2_0FlashThinkingExperimental => {
                 Some("gemini-2.0-flash-thinking-exp-1219".to_owned())

--- a/llm_client/src/clients/google_ai.rs
+++ b/llm_client/src/clients/google_ai.rs
@@ -38,9 +38,9 @@ impl GoogleAIStdioClient {
 
     fn model(&self, model: &LLMType) -> Option<String> {
         match model {
-            LLMType::GeminiPro => Some("gemini-1.5-pro".to_owned()),
-            LLMType::GeminiProFlash => Some("gemini-1.5-flash".to_owned()),
-            LLMType::Gemini2_0Flash => Some("gemini-2.0-flash".to_owned()),
+            LLMType::GeminiPro => Some("gemini-2.0-flash-001".to_owned()),
+            LLMType::GeminiProFlash => Some("gemini-2.0-flash-001".to_owned()),
+            LLMType::Gemini2_0Flash => Some("gemini-2.0-flash-001".to_owned()),
             LLMType::Gemini2_0FlashExperimental => Some("gemini-2.0-flash-exp".to_owned()),
             LLMType::Gemini2_0FlashThinkingExperimental => {
                 Some("gemini-2.0-flash-thinking-exp-1219".to_owned())


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_1998_f3b96484 Tries to fix: #1998

Refactor: Updated `GeminiPro` and `GoogleAIStdio` clients to use **Gemini 2.0 Flash** (`google/gemini-2.0-flash-001`) as the fallback model.

- **Modified:** Model type mappings in `google_ai.rs` and `gemini_pro.rs` to use the newer Gemini 2.0 Flash model.
- **Verified:** Changes with `cargo check` and confirmed build success.

Please review these updates to the LLM client fallback behavior. 🤖