### PR TITLE
[agent_farm] upgrade sidecar version (Run ID: codestoryai_sidecar_issue_2002_b9e4d332)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "sidecar"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidecar"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2002_b9e4d332 Tries to fix: #2002

Upgrade: _Sidecar version_ from **0.1.30** to **0.1.31**

- **Updated:** `sidecar/Cargo.toml` package version.
- **Verified:** All dependencies compile successfully with `cargo check`.

👥 Ready for review - straightforward version bump with clean compilation.