### PR TITLE
[agent_farm] write a bin file which uses the CodeStoryProvider with O3MiniHigh model (Run ID: codestoryai_sidecar_issue_2016_312db4f3)

### DIFF
--- a/sidecar/src/bin/codestory_o3mini.rs
+++ b/sidecar/src/bin/codestory_o3mini.rs
@@ -1,0 +1,61 @@
+use llm_client::{
+    broker::LLMBroker,
+    clients::types::{LLMClientCompletionRequest, LLMClientMessage, LLMType},
+    provider::{CodeStoryLLMTypes, LLMProvider, LLMProviderAPIKeys, CodestoryAccessToken},
+};
+use std::collections::HashMap;
+use tokio;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create LLM broker
+    let broker = LLMBroker::new().await?;
+
+    // Create a CodeStory provider with O3MiniHigh model
+    let provider = LLMProvider::CodeStory(CodeStoryLLMTypes {
+        llm_type: Some(LLMType::O3MiniHigh),
+    });
+
+    // Example messages for the model
+    let messages = vec![
+        LLMClientMessage::system("You are a helpful AI assistant.".to_string()),
+        LLMClientMessage::user("Hello! How can you help me today?".to_string()),
+    ];
+
+    // Create the completion request
+    let request = LLMClientCompletionRequest::new(
+        LLMType::O3MiniHigh,
+        messages,
+        0.7, // temperature
+        None, // frequency penalty
+    );
+
+    // Example access token (replace with actual token in production)
+    let api_key = LLMProviderAPIKeys::CodeStory(CodestoryAccessToken::new(
+        "your_access_token".to_string(),
+    ));
+
+    // Create channel for receiving completion responses
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+
+    // Stream completion in a separate task
+    let completion_task = tokio::spawn(async move {
+        let metadata = HashMap::new();
+        broker
+            .stream_completion(api_key, request, provider, metadata, sender)
+            .await
+    });
+
+    // Process streaming responses
+    while let Some(response) = receiver.recv().await {
+        if let Some(delta) = response.delta() {
+            print!("{}", delta);
+        }
+    }
+
+    // Wait for completion task and get final result
+    let result = completion_task.await??;
+    println!("\nFinal response: {}", result.answer_up_until_now());
+
+    Ok(())
+}


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2016_312db4f3 Tries to fix: #2016

**feat(sidecar):** Added new binary `codestory_o3mini` that demonstrates streaming completion with O3MiniHigh model.

- **Implementation:** Uses `LLMBroker` to handle streaming responses from CodeStoryProvider, with proper error handling and response processing
- **Added:** Example usage showing system/user message handling and token streaming

Looking for review on the stream handling implementation and error management approach. 🔍