### PR TITLE
[agent farm] fix compile (Run ID: codestoryai_sidecar_issue_2025_99901108)

### DIFF
--- a/sidecar/src/mcts/action_node.rs
+++ b/sidecar/src/mcts/action_node.rs
@@ -457,6 +457,10 @@ impl SearchTreeMinimal {
         }
     }
 
+    pub fn nodes(&self) -> impl Iterator<Item = &ActionNode> {
+        self.index_to_node.values()
+    }
+
     pub async fn save_serialised_graph(&self, log_dir: &str, request_id: &str) {
         let graph_serialised = match serde_json::to_string(&self) {
             Ok(serialized) => serialized,

--- a/sidecar/src/webserver/agentic.rs
+++ b/sidecar/src/webserver/agentic.rs
@@ -873,23 +873,23 @@ pub async fn get_mcts_data(
                     if let Some(tool_type) = tool_type {
                         // Get color based on tool type using the same logic as print_tree
                         let color = match tool_type {
-                            ToolType::CodeEditor => "#4A90E2",      // blue
-                            ToolType::FindFile => "#F5A623",        // yellow
-                            ToolType::CodeEditing => "#9013FE",     // purple
-                            ToolType::ListFiles => "#F5A623",       // yellow
+                            ToolType::CodeEditing => "#4A90E2",      // blue
+                            ToolType::FindFiles => "#F5A623",        // yellow
+                            ToolType::ListFiles => "#F5A623",        // yellow
                             ToolType::SearchFileContentWithRegex => "#9013FE", // purple
-                            ToolType::OpenFile => "#E91E63",        // magenta
-                            ToolType::SemanticSearch => "#9013FE",  // purple
-                            ToolType::LSPDiagnostics => "#00BCD4",  // cyan
-                            ToolType::TerminalCommand => "#FF5252",  // red
+                            ToolType::OpenFile => "#E91E63",         // magenta
+                            ToolType::SemanticSearch => "#9013FE",   // purple
+                            ToolType::LSPDiagnostics => "#00BCD4",   // cyan
+                            ToolType::TerminalCommand => "#FF5252",   // red
                             ToolType::AskFollowupQuestions => "#757575", // gray
                             ToolType::AttemptCompletion => "#4CAF50", // green
                             ToolType::RepoMapGeneration => "#E91E63", // magenta
-                            ToolType::TestRunner => "#FF5252",      // red
-                            ToolType::Reasoning => "#4A90E2",       // blue
-                            ToolType::ContextCrunching => "#4A90E2", // blue
+                            ToolType::TestRunner => "#FF5252",       // red
+                            ToolType::Reasoning => "#4A90E2",        // blue
+                            ToolType::ContextCrunching => "#4A90E2",  // blue
                             ToolType::RequestScreenshot => "#757575", // gray
-                            ToolType::McpTool => "#00BCD4",         // cyan
+                            ToolType::McpTool(_) => "#00BCD4",       // cyan
+                            _ => "#9E9E9E",                          // default gray for other variants
                         };
                         
                         html.push_str(&format!("<div class='node'>\n"));

--- a/sidecar/src/webserver/agentic.rs
+++ b/sidecar/src/webserver/agentic.rs
@@ -43,6 +43,7 @@ use crate::webserver::plan::{
 use crate::{application::application::Application, user_context::types::UserContext};
 
 use super::types::ApiResponse;
+use crate::agentic::tool::r#type::ToolType;
 
 /// Tracks and manages probe requests in a concurrent environment.
 /// This struct is responsible for keeping track of ongoing probe requests
@@ -866,7 +867,7 @@ pub async fn get_mcts_data(
             html.push_str("<div class='mcts-tree'>");
             
             // Add nodes in order
-            for node in data.index_to_node.values() {
+            for node in data.nodes() {
                 if let Some(action) = &node.action() {
                     let tool_type = action.to_tool_type();
                     if let Some(tool_type) = tool_type {


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2025_99901108 Tries to fix: #2025

✅ **Fix: Resolved compile errors in `agentic.rs` and `action_node.rs`**

- Added a `nodes()` getter method to `SearchTreeMinimal` to provide proper access to node data.
- Imported the missing `ToolType` enum and updated the loop in `get_mcts_data` to use the new getter method, fixing the compile errors.

Please review these changes.