### PR TITLE
[agent farm] (Run ID: codestoryai_sidecar_issue_2029_b1e2f281)

### DIFF
--- a/llm_client/src/clients/anthropic.rs
+++ b/llm_client/src/clients/anthropic.rs
@@ -302,11 +302,12 @@ impl AnthropicRequest {
                 content.extend(tool_return);
 
                 // If this message is marked as a cache point, set it on the last content
-                if message.is_cache_point() && !content.is_empty() {
-                    let last_idx = content.len() - 1;
-                    content[last_idx].set_cache_control(Some(AnthropicCacheControl {
-                        r#type: AnthropicCacheType::Ephemeral,
-                    }));
+                if message.is_cache_point() {
+                    if let Some(last_content) = content.last_mut() {
+                        last_content.set_cache_control(Some(AnthropicCacheControl {
+                            r#type: AnthropicCacheType::Ephemeral,
+                        }));
+                    }
                 }
 
                 AnthropicMessage {

--- a/llm_client/src/clients/anthropic.rs
+++ b/llm_client/src/clients/anthropic.rs
@@ -96,10 +96,10 @@ impl AnthropicMessageContent {
 
     fn set_cache_control(&mut self, cache_control: Option<AnthropicCacheControl>) {
         match self {
-            Self::Text { ref mut cache_control: cc, .. } => *cc = cache_control,
-            Self::Image { ref mut cache_control: cc, .. } => *cc = cache_control,
-            Self::ToolUse { ref mut cache_control: cc, .. } => *cc = cache_control,
-            Self::ToolReturn { ref mut cache_control: cc, .. } => *cc = cache_control,
+            Self::Text { cache_control: ref mut cc, .. } => *cc = cache_control,
+            Self::Image { cache_control: ref mut cc, .. } => *cc = cache_control,
+            Self::ToolUse { cache_control: ref mut cc, .. } => *cc = cache_control,
+            Self::ToolReturn { cache_control: ref mut cc, .. } => *cc = cache_control,
         }
     }
 }
@@ -260,10 +260,9 @@ impl AnthropicRequest {
                 let mut anthropic_message_content =
                     AnthropicMessageContent::text(message.content().to_owned(), None);
                 if message.is_cache_point() {
-                    anthropic_message_content =
-                        anthropic_message_content.cache_control(Some(AnthropicCacheControl {
-                            r#type: AnthropicCacheType::Ephemeral,
-                        }));
+                    anthropic_message_content.set_cache_control(Some(AnthropicCacheControl {
+                        r#type: AnthropicCacheType::Ephemeral,
+                    }));
                 }
                 vec![anthropic_message_content]
             })


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2029_b1e2f281 Tries to fix: #2029

🔧 **Enhancement:** Added cache point support for all Anthropic message content types

- **Updated:** `AnthropicMessageContent` to support cache control for images, tool use, and tool return content types, extending the existing text-only caching
- **Improved:** Message construction logic to set cache points on the last content item regardless of type, ensuring consistent caching behavior

Would appreciate review from team members familiar with our caching implementation! 🙏