### PR TITLE
[agent farm] add deepseek r1 fireworks (Run ID: codestoryai_sidecar_issue_2035_cf0ee2de)

### DIFF
--- a/llm_client/src/clients/fireworks.rs
+++ b/llm_client/src/clients/fireworks.rs
@@ -150,6 +150,9 @@ impl FireworksAIClient {
             LLMType::Llama3_1_70bInstruct => {
                 Some("accounts/fireworks/models/llama-v3p1-70b-instruct".to_owned())
             }
+            LLMType::DeepSeekR1 => {
+                Some("accounts/fireworks/models/deepseek-r1".to_owned())
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2035_cf0ee2de Tries to fix: #2035

🚀 **Model Support:** Added DeepSeek R1 model to Fireworks.ai provider integration

- **Added:** Model mapping in `FireworksAIClient::model_str()` to support `accounts/fireworks/models/deepseek-r1`
- **Updated:** Model variant handling in client implementation to cleanly integrate with existing Fireworks.ai infrastructure

Ready for review! 🔍