### PR TITLE
[agent_farm] pass the configured llm in agent_bin for context crunching as well (Run ID: codestoryai_sidecar_issue_2050_e1d5cafc)

### DIFF
--- a/sidecar/src/bin/agent_bin.rs
+++ b/sidecar/src/bin/agent_bin.rs
@@ -150,7 +150,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         LLMProviderAPIKeys::Anthropic(AnthropicAPIKey::new(args.anthropic_api_key.to_owned())),
     );
     // Define context crunching LLM properties - using the same model as the main agent for now
-    let _context_crunching_llm = Some(llm_provider.clone());
+    let context_crunching_llm = Some(llm_provider.clone());
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
     let message_properties = SymbolEventMessageProperties::new(
@@ -213,7 +213,7 @@ Your thinking should be thorough and so it's fine if it's very long."#,
             Some(args.repo_name.clone()),
             message_properties,
             false, // not in devtools context
-            None, // No context crunching LLM for agent_bin
+            context_crunching_llm, // Pass the configured LLM for context crunching
         )
         .await;
     println!("agent::tool_use::end");


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2050_e1d5cafc Tries to fix: #2050

I'll analyze the MCTS data and provide a concise PR message:

🔧 **Agent Enhancement:** Configured context crunching LLM in agent_bin

- **Modified:** Changed `_context_crunching_llm` to an actively used variable
- **Updated:** Now passing the same LLM configuration for both main agent and context crunching
- **Verified:** All changes compile successfully through `cargo check`

This change improves consistency in the agent's behavior by ensuring the same LLM is used for both main operations and context analysis, enhancing the agent's contextual understanding capabilities.