### PR TITLE
[agent_farm] add `get_mcts_data` as a webserver endpoint (Run ID: codestoryai_sidecar_issue_2054_25cfc756)

### DIFF
--- a/sidecar/src/bin/webserver.rs
+++ b/sidecar/src/bin/webserver.rs
@@ -252,6 +252,10 @@ fn agentic_router() -> Router {
             "/user_handle_session_undo",
             post(sidecar::webserver::agentic::handle_session_undo),
         )
+        .route(
+            "/get_mcts_data",
+            post(sidecar::webserver::agentic::get_mcts_data),
+        )
 }
 
 fn tree_sitter_router() -> Router {


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2054_25cfc756 Tries to fix: #2054

I'll create a concise, well-formatted GitHub PR message based on the MCTS data:

🚀 **New Endpoint Added:** Integrated `get_mcts_data` endpoint to the webserver

- **Added:** New route in `agentic_router()` function for displaying MCTS data
- **Integration:** Endpoint connects to existing session service method that retrieves search tree data
- **Visualization:** Returns HTML response with color-coded tool types and inputs/outputs

This PR adds the ability to visualize Monte Carlo Tree Search data through a dedicated endpoint, making it easier to debug and analyze agent behavior. Ready for review!