### PR TITLE
Support checkpoints (Run ID: codestoryai_sidecar_issue_2058_ed21739e)

### DIFF
--- a/sidecar/src/agentic/tool/session/service.rs
+++ b/sidecar/src/agentic/tool/session/service.rs
@@ -1037,6 +1037,25 @@ impl SessionService {
         Ok(())
     }
 
+    pub async fn move_to_checkpoint(
+        &self,
+        session_id: &str,
+        exchange_id: &str,
+        storage_path: String,
+    ) -> Result<(), SymbolError> {
+        let session_maybe = self.load_from_storage(storage_path.to_owned()).await;
+        if session_maybe.is_err() {
+            return Ok(());
+        }
+        let mut session = session_maybe.expect("is_err to hold");
+        
+        // Mark exchanges as deleted or not deleted based on the checkpoint
+        session = session.move_to_checkpoint(exchange_id).await?;
+        
+        self.save_to_storage(&session, None).await?;
+        Ok(())
+    }
+
     pub async fn delete_exchanges_until(
         &self,
         exchange_id: &str,

--- a/sidecar/src/agentic/tool/session/session.rs
+++ b/sidecar/src/agentic/tool/session/session.rs
@@ -1093,6 +1093,29 @@ impl Session {
         Ok(self)
     }
 
+    pub async fn move_to_checkpoint(
+        mut self,
+        exchange_id: &str,
+    ) -> Result<Self, SymbolError> {
+        // Find the index of the target exchange
+        let target_index = self.exchanges.iter().position(|exchange| &exchange.exchange_id == exchange_id);
+        
+        if let Some(target_index) = target_index {
+            // Mark exchanges as compressed (deleted) or not compressed based on the checkpoint
+            for (i, exchange) in self.exchanges.iter_mut().enumerate() {
+                if i <= target_index {
+                    // Exchanges up to and including the target are not compressed
+                    exchange.is_compressed = false;
+                } else {
+                    // Exchanges after the target are compressed (deleted)
+                    exchange.is_compressed = true;
+                }
+            }
+        }
+        
+        Ok(self)
+    }
+
     pub async fn react_to_feedback(
         mut self,
         exchange_id: &str,

--- a/sidecar/src/bin/webserver.rs
+++ b/sidecar/src/bin/webserver.rs
@@ -253,6 +253,10 @@ fn agentic_router() -> Router {
             post(sidecar::webserver::agentic::handle_session_undo),
         )
         .route(
+            "/move_to_checkpoint",
+            post(sidecar::webserver::agentic::move_to_checkpoint),
+        )
+        .route(
             "/get_mcts_data",
             post(sidecar::webserver::agentic::get_mcts_data),
         )

--- a/sidecar/src/webserver/agentic.rs
+++ b/sidecar/src/webserver/agentic.rs
@@ -728,6 +728,42 @@ pub async fn handle_session_undo(
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AgenticMoveToCheckpoint {
+    session_id: String,
+    exchange_id: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AgenticMoveToCheckpointResponse {
+    done: bool,
+}
+
+impl ApiResponse for AgenticMoveToCheckpointResponse {}
+
+pub async fn move_to_checkpoint(
+    Extension(app): Extension<Application>,
+    Json(AgenticMoveToCheckpoint {
+        session_id,
+        exchange_id,
+    }): Json<AgenticMoveToCheckpoint>,
+) -> Result<impl IntoResponse> {
+    println!("webserver::agent_session::move_to_checkpoint::hit");
+    println!(
+        "webserver::agent_session::move_to_checkpoint::session_id({})",
+        &session_id
+    );
+
+    let session_storage_path =
+        check_session_storage_path(app.config.clone(), session_id.to_string()).await;
+
+    let session_service = app.session_service.clone();
+    let _ = session_service
+        .move_to_checkpoint(&session_id, &exchange_id, session_storage_path)
+        .await;
+    Ok(Json(AgenticMoveToCheckpointResponse { done: true }))
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AgenticEditFeedbackExchangeResponse {
     success: bool,
 }


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2058_ed21739e Tries to fix: #2058

✅ **Feature: Support session checkpoints**

This PR implements a new `/api/agentic/move_to_checkpoint` endpoint, allowing navigation to specific exchange IDs within a session.  This endpoint enables selective context passing to LLMs by marking older exchanges as uncompressed and newer exchanges as compressed.  Please review the changes.