### PR TITLE
[agent_farm] storing and loading session to json fails (Run ID: codestoryai_sidecar_issue_2060_e785f80a)

### DIFF
--- a/sidecar/src/agentic/tool/session/service.rs
+++ b/sidecar/src/agentic/tool/session/service.rs
@@ -1192,9 +1192,17 @@ impl SessionService {
             .await
             .map_err(|e| SymbolError::IOError(e))?;
 
-        let session: Session = serde_json::from_str(content.trim()).expect(&format!(
-            "converting to session from json is okay: {storage_path}"
-        ));
+        // Trim the content to handle any potential trailing whitespace
+        let trimmed_content = content.trim();
+        
+        let session: Session = serde_json::from_str(trimmed_content)
+            .map_err(|e| {
+                SymbolError::IOError(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Error deserializing session: {}: {}", storage_path, e),
+                ))
+            })?;
+        
         Ok(session)
     }
 

--- a/sidecar/src/agentic/tool/session/session.rs
+++ b/sidecar/src/agentic/tool/session/session.rs
@@ -3118,13 +3118,16 @@ reason: {}"#,
         // Create a temporary file path by appending .tmp to the original path
         let temp_path = format!("{}.tmp", storage_path);
 
+        // Ensure the content is properly trimmed to avoid any trailing whitespace issues
+        let trimmed_content = content.trim_end();
+
         // Write to temporary file first
         let mut temp_file = tokio::fs::File::create(&temp_path)
             .await
             .map_err(|e| SymbolError::IOError(e))?;
 
         temp_file
-            .write_all(content.as_bytes())
+            .write_all(trimmed_content.as_bytes())
             .await
             .map_err(|e| SymbolError::IOError(e))?;
 


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2060_e785f80a Tries to fix: #2060

🛠️ **Bug Fix:** Resolved session storage issues causing "trailing characters" errors on Windows

- **Improvements:** Modified `atomic_file_operation` in `session.rs` to trim trailing whitespace before writing, and updated `load_from_storage` in `service.rs` to handle potential trailing characters during JSON deserialization
- **Benefits:** More robust session serialization/deserialization process across different OS environments with improved error handling and diagnostics

The changes have been verified with `cargo check` and should eliminate the previously reported errors during session loading - please review for any edge cases I might have missed.