### PR TITLE
[agent farm] replace current sonnet with claude-3-7-sonnet-20250219 (Run ID: codestoryai_sidecar_issue_2088_10418004)

### DIFF
--- a/llm_client/src/clients/anthropic.rs
+++ b/llm_client/src/clients/anthropic.rs
@@ -401,7 +401,7 @@ impl AnthropicClient {
     fn get_model_string(&self, llm_type: &LLMType) -> Result<String, LLMClientError> {
         match llm_type {
             LLMType::ClaudeOpus => Ok("claude-3-opus-20240229".to_owned()),
-            LLMType::ClaudeSonnet => Ok("claude-3-5-sonnet-20241022".to_owned()),
+            LLMType::ClaudeSonnet => Ok("claude-3-7-sonnet-20250219".to_owned()),
             LLMType::ClaudeHaiku => Ok("claude-3-haiku-20240307".to_owned()),
             LLMType::Custom(model) => Ok(model.to_owned()),
             _ => Err(LLMClientError::UnSupportedModel),

--- a/llm_client/src/clients/codestory.rs
+++ b/llm_client/src/clients/codestory.rs
@@ -165,7 +165,7 @@ impl CodeStoryClient {
             LLMType::DeepSeekCoder33BInstruct => {
                 Ok("deepseek-ai/deepseek-coder-33b-instruct".to_owned())
             }
-            LLMType::ClaudeSonnet => Ok("claude-3-5-sonnet-20241022".to_owned()), // updated to latest sonnet
+            LLMType::ClaudeSonnet => Ok("claude-3-7-sonnet-20250219".to_owned()), // updated to latest sonnet
             LLMType::ClaudeHaiku => Ok("claude-3-5-haiku-20241022".to_owned()), // updated to latest haiku
             LLMType::GeminiPro => Ok("google/gemini-flash-1.5".to_owned()),
             LLMType::GeminiProFlash => Ok("gemini-1.5-flash".to_owned()),


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2088_10418004 Tries to fix: #2088

🔄 **Model Update:** Upgraded Claude Sonnet model version from `claude-3-5-sonnet-20241022` to `claude-3-7-sonnet-20250219` across LLM clients

- **Updated:** Model version string in `anthropic.rs` and `codestory.rs` clients
- **Standardized:** Consistent model version references across codebase

Please review these version alignment changes that keep us current with Anthropic's latest model releases. 👀