### PR TITLE
[agent farm] (Run ID: codestoryai_sidecar_issue_2092_22ab5de3)

### DIFF
--- a/llm_client/src/clients/types.rs
+++ b/llm_client/src/clients/types.rs
@@ -748,6 +748,11 @@ impl LLMClientCompletionStringRequest {
     pub fn get_max_tokens(&self) -> Option<usize> {
         self.max_tokens
     }
+
+    pub fn set_thinking_budget(mut self, thinking_budget: usize) -> Self {
+        self.thinking_budget = Some(thinking_budget);
+        self
+    }
 }
 
 impl LLMClientCompletionRequest {
@@ -764,6 +769,7 @@ impl LLMClientCompletionRequest {
             frequency_penalty,
             stop_words: None,
             max_tokens: None,
+            thinking_budget: None,
         }
     }
 


### PR DESCRIPTION
agent_instance: codestoryai_sidecar_issue_2092_22ab5de3 Tries to fix: #2092

🔧 **LLM Client Enhancement:** Added `thinking_budget` field to the LLM completion request types

- **Added:** Optional `thinking_budget` field to `LLMClientCompletionRequest` struct with corresponding setter method following builder pattern
- **Updated:** Core struct initialization while maintaining existing APIs

👥 Please review these changes for the agent farm implementation.