### PR TITLE
[sidecar] better error handling for anthropic

### DIFF
--- a/llm_client/src/clients/anthropic.rs
+++ b/llm_client/src/clients/anthropic.rs
@@ -470,6 +470,12 @@ impl AnthropicClient {
             return Err(LLMClientError::UnauthorizedAccess);
         }
 
+        if let Err(e) = response_stream.error_for_status_ref() {
+            let body = response_stream.text().await?;
+            println!("anthropic::err {body}");
+            return Err(e.into());
+        }
+
         let mut event_source = response_stream.bytes_stream().eventsource();
 
         // let event_next = event_source.next().await;


### PR DESCRIPTION
we were eating some errors


sample output

stdout:
```
anthropic::err({"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your organization’s rate limit of 200,000 input tokens per minute. For details, refer to: https://docs.anthropic.com/en/api/rate-limits; see the response headers for current usage. Please reduce the prompt length or the maximum tokens requested, or try again later. You may also contact sales at https://www.anthropic.com/contact-sales to discuss your options for a rate limit increase."}})
```

error message:
```
Error processing input: Reqwest error: HTTP status client error (429 Too Many Requests) for url (https://api.anthropic.com/v1/messages)
```